### PR TITLE
Jenkins: clone repo into Go workspace

### DIFF
--- a/script/publish_latest_tag
+++ b/script/publish_latest_tag
@@ -1,7 +1,8 @@
 #!/bin/sh -eux
 
 WORKSPACE=${WORKSPACE:-$PWD}
-REPO_DIR=$(mktemp -d)
+export GOPATH=$(mktemp -d)
+REPO_DIR="${GOPATH}/src/github.com/fluidkeys/fluidkeys"
 DEB_PACKAGE_ARCHIVE_REPO=$(mktemp -d)
 ARTIFACTS_DIR="${WORKSPACE}/artifacts"
 mkdir -p "${ARTIFACTS_DIR}"


### PR DESCRIPTION
1. set GOPATH to a temp directory
2. clone fluidkeys into GOPATH/src/github.com/fluidkeys/fluidkeys

When `script/publish-latest_tag` runs, it makes a fresh `git clone` of
the repo, then `cd`s there and runs `make` etc.

Because of the way Go workspaces work, if we want to import local
packages (e.g. `backupzip`, `pgpkey` etc) by doing:

```
import "github.com/fluidkeys/fluidkeys/pgpkey"
```

... then our own `fluidkeys` repo *must* be checked out into
`$GOPATH/src/github.com/fluidkeys/fluidkeys`