### PR TITLE
Move apt to download.fluidkeys.com/desktop/apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ sudo apt-key adv --keyserver pool.sks-keyservers.net --recv-key 0x36D46F41F57A1D
 ### Add our apt repository
 
 ```
-echo 'deb [arch=amd64] https://download.fluidkeys.com any main' | sudo tee /etc/apt/sources.list.d/fluidkeys.list
+echo 'deb [arch=amd64] https://download.fluidkeys.com/desktop/apt any main' | sudo tee /etc/apt/sources.list.d/fluidkeys.list
 ```
 
 ### Install

--- a/script/publish_latest_tag
+++ b/script/publish_latest_tag
@@ -80,7 +80,7 @@ upload_apt_repo() {
     rsync \
         -razv \
         -e "ssh -i ${WORKSPACE}/.secret/download-fluidkeys-com.id_rsa" \
-        ${WORKSPACE}/pkg/apt-repo/ download-fluidkeys-com@download.fluidkeys.com:~/html
+        ${WORKSPACE}/pkg/apt-repo/ download-fluidkeys-com@download.fluidkeys.com:~/html/desktop/apt
 }
 
 publish_tag_as_homebrew_formula() {

--- a/script/publish_latest_tag
+++ b/script/publish_latest_tag
@@ -51,7 +51,7 @@ copy_down_existing_deb_files() {
 
 make_install_into_deb_pkg_location() {
     cd ${REPO_DIR}
-    PREFIX=${WORKSPACE}/pkg/debian make install
+    PREFIX=${REPO_DIR}/pkg/debian make install
     cd -
 }
 

--- a/script/publish_latest_tag
+++ b/script/publish_latest_tag
@@ -79,6 +79,7 @@ make_apt_repo() {
 upload_apt_repo() {
     rsync \
         -razv \
+        --delete \
         -e "ssh -i ${WORKSPACE}/.secret/download-fluidkeys-com.id_rsa" \
         ${WORKSPACE}/pkg/apt-repo/ download-fluidkeys-com@download.fluidkeys.com:~/html/desktop/apt
 }

--- a/script/publish_latest_tag
+++ b/script/publish_latest_tag
@@ -139,7 +139,11 @@ build_deb_file_for_tag() {
 }
 
 clean_up() {
-    rm -rf "${DEB_PACKAGE_ARCHIVE_REPO}"
+    CLEAN_UP=${CLEAN_UP:-1}
+    if [ "${CLEAN_UP}" -eq "1" ]; then
+        rm -rf "${DEB_PACKAGE_ARCHIVE_REPO}"
+        rm -rf "${GOPATH}"
+    fi
 }
 
 

--- a/script/publish_latest_tag
+++ b/script/publish_latest_tag
@@ -72,7 +72,7 @@ make_deb_package() {
 }
 
 make_apt_repo() {
-    reprepro -b ${REPO_DIR}/pkg/apt-repo includedeb any ${DEB_PACKAGE_ARCHIVE_REPO}/fluidkeys*.deb
+    reprepro -b ${WORKSPACE}/pkg/apt-repo includedeb any ${DEB_PACKAGE_ARCHIVE_REPO}/fluidkeys*.deb
 }
 
 


### PR DESCRIPTION
Rather than the root of download.fluidkeys.com which we'll probably want to
use for something else, like an instructions page.

And lots of fixes:

* `make install` into REPO_DIR not WORKSPACE
* Use reprepro in WORKSPACE not REPO_DIR
* Control cleanup with CLEAN_UP=1|0
* Apt repo: delete remote files if they don't exist