### PR TITLE
Ensure `make compile` works from any location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ go:
 before_install:
   - sudo apt install tree
   - go get -u github.com/golang/dep/cmd/dep
-  - make install_dependencies
 
 script: make test
 

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,18 @@ MAIN_GO_FILES=fluidkeys/main.go
 compile: clean build/bin/fk
 
 
+TMPGOPATH := $(shell mktemp -d)
+
 build/bin/fk: $(MAIN_GO_FILES)
 	@mkdir -p build/bin
-	go build -o $@ $(MAIN_GO_FILES)
+	@echo "Creating temporary GOPATH $(TMPGOPATH)"
+
+	rsync -raz $(PWD)/vendor/ $(TMPGOPATH)/src
+
+	mkdir -p $(TMPGOPATH)/src/github.com/fluidkeys
+	ln -s $(PWD) $(TMPGOPATH)/src/github.com/fluidkeys/fluidkeys
+
+	GOPATH=$(TMPGOPATH) go build -o $@ $(MAIN_GO_FILES)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,8 @@ MAIN_GO_FILES=fluidkeys/main.go
 # ultimately be installed to PREFIX (/usr/local), for example
 # ./build/bin/fk, ./build/share etc
 .PHONY: compile
-compile: clean install_dependencies build/bin/fk
+compile: clean build/bin/fk
 
-.PHONY: install_dependencies
-install_dependencies:
-	dep ensure
 
 build/bin/fk: $(MAIN_GO_FILES)
 	@mkdir -p build/bin

--- a/README.md
+++ b/README.md
@@ -41,12 +41,6 @@ brew install fluidkeys
 
 If you want to hack on Fluidkeys locally you'll need [Go 1.10](https://golang.org/dl/) and [dep](https://github.com/golang/dep#installation).
 
-Get dependencies:
-
-```
-make install_dependencies
-```
-
 Run:
 
 ```

--- a/script/test_make_compile
+++ b/script/test_make_compile
@@ -1,14 +1,33 @@
 #!/bin/sh -eu
 
-run_make_compile() {
-    make compile || exit 1
+THIS_FILE=$0
+THIS_DIR=$(dirname $0)
+
+PREFIX_DIR=$(mktemp -d)
+
+copy_repo_to_random_directory() {
+    TEMP_REPO_DIR=$(mktemp -d)
+
+    cp -R "${THIS_DIR}/../"  "${TEMP_REPO_DIR}"
+}
+
+run_make_compile_without_goroot_or_gopath() {
+    cd "${TEMP_REPO_DIR}"
+    GOROOT="" GOPATH="" PREFIX=${PREFIX_DIR} make compile || exit 1
+    cd -
+}
+
+ensure_fk_binary_exists_in_build() {
+  if [ ! -f "${THIS_DIR}/../build/bin/fk" ] ; then
+      echo "Binary doesn't seem to have been installed in build/bin/fk"
+  fi
 }
 
 print_success() {
     echo 'OK: `make compile` ran successfully'
 }
 
-
-
-run_make_compile
+copy_repo_to_random_directory
+run_make_compile_without_goroot_or_gopath
+ensure_fk_binary_exists_in_build
 print_success


### PR DESCRIPTION
On Jenkins and when installed via Homebrew, we don't know that the repo has
been checked out into `$GOPATH/src/github.com/fluidkeys/fluidkeys`
(brew unpacks a tarball into a temp directory, for example).

So, make a temporary directory, fake `GOPATH` and do some copying &
symlinking to ensure $GOPATH/src contains all the dependencies (external
and internal) that fluidkeys relies on.

This is not pretty, but I don't know a better way at the moment.

I've updated script/test_make_compile to test `make compile` in a temp dir.

Also remove `make install_dependencies`

We commit these into `vendor` now. `make install_dependencies` was from the
time when you had to run `go get ...`, which we no longer need.

Further, we definitely shouldn't run `dep` from `make compile` since we
want to compile the repo *exactly as it is now*, *not* mess around with
dependencies.

For example, imagine we've just unpacked a tarball of a specific release,
vendor directory and all. We know exactly what code is in that tarball (and
checked the sig). The last thing we want is for dep to change anything.