### PR TITLE
fluidkeys/crypto : depend on tagged version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,6 @@
 
 
 [[projects]]
-  branch = "encrypt-private-key"
   digest = "1:63134f6042f32182e3f49eeefe90d14a55ec93d1e51744645e36e502cd1abc1b"
   name = "github.com/fluidkeys/crypto"
   packages = [
@@ -16,6 +15,7 @@
   ]
   pruneopts = ""
   revision = "899979fc5077af94efd47af6d07e2f713918ec0c"
+  version = "2018-08-22"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
   name = "github.com/sethvargo/go-diceware"
 
 [[constraint]]
-  branch = "encrypt-private-key"
+  version = "2018-08-22"
   name = "github.com/fluidkeys/crypto"
 
 [[constraint]]


### PR DESCRIPTION
I can see that it's going to get complicated maintaining a fork of
golang/crypto where some bits of functionality are in our fork, some
bits are in upstream, etc.

I already need to make another tweak in our fork (todo with revocation
certificates). I'm probably going to have to make a custom branch which
is encrypt-private-key + revocation-certificate

... so how should `fluidkeys` depend on `crypto` ?

My best suggestion at the moment is that we make whatever whacky
branches we need for a particular combination of commits at a given
time, and *tag* that branch with a date eg `2018-08-22` then point
fluidkeys to that.

I've tagged the crypto repo with that date, pointing to the tip of
`encrypt-private-keys`. Then, if I want to cherry-pick on a commit
related to revocation certificates, I can do that in a branch and tag it
with a new date, and point fluidkeys to that.

As things get merged into upstream, we can rebase our master against
golang/master and (hopefully) our local branch commits will disappear.
We can keep the old tags kicking around, but potentially make a new
date-tag simply pointing at master (if upstream takes all our changes.)

Then when the next feature comes around, we branch, do the work, tag,
update dependency, etc etc