### PR TITLE
Use FLUIDKEYS_DIR if set (not ~/.config/fluidkeys)

### DIFF
--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -125,6 +125,16 @@ func main() {
 }
 
 func getFluidkeysDirectory() (string, error) {
+	dirFromEnv := os.Getenv("FLUIDKEYS_DIR")
+
+	if dirFromEnv != "" {
+		return dirFromEnv, nil
+	} else {
+		return makeFluidkeysHomeDirectory()
+	}
+}
+
+func makeFluidkeysHomeDirectory() (string, error) {
 	homeDirectory, err := homedir.Dir()
 
 	if err != nil {


### PR DESCRIPTION
This allows you to run e.g.

```
FLUIDKEYS_DIR=/tmp/fluidkeys fk
```

... and config / backups will be stored there instead of in the home
directory.