### PR TITLE
Add `Fingerprint` class, use instead of string

### DIFF
--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -1,0 +1,96 @@
+package fingerprint
+
+import (
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type fingerprintBytes = [20]byte
+
+// Fingerprint represents a 20-character OpenPGP fingerprint.
+type Fingerprint struct {
+	fingerprintBytes
+
+	isSet bool
+}
+
+// Parse takes a string and returns a Fingerprint.
+// Accepts fingerprints with spaces, uppercase, lowercase etc.
+func Parse(fp string) (Fingerprint, error) {
+	var nilFingerprint Fingerprint
+	withoutSpaces := strings.Replace(fp, " ", "", -1)
+
+	expectedPattern := `^(0x)?[A-Fa-f0-9]{40}$`
+	if matched, err := regexp.MatchString(expectedPattern, withoutSpaces); !matched || err != nil {
+		return nilFingerprint, fmt.Errorf("fingerprint doesn't match pattern '%v', err=%v", expectedPattern, err)
+	}
+
+	withoutLeading0x := strings.TrimLeft(withoutSpaces, "0x")
+
+	bytes, err := hex.DecodeString(withoutLeading0x)
+	if err != nil {
+		return nilFingerprint, err
+	}
+	var f Fingerprint
+	for i, b := range bytes {
+		f.fingerprintBytes[i] = b
+	}
+	f.isSet = true
+	return f, nil
+}
+
+// MustParse takes a string and returns a Fingerprint. If the
+// string is not a valid fingerprint (e.g. 40 hex characters) it will panic.
+func MustParse(fp string) Fingerprint {
+	result, err := Parse(fp)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// Return a human-friendly version of the fingerprint, which should be a 40
+// character hex string.
+// `AB01 AB01 AB01 AB01 AB01  AB01 AB01 AB01 AB01 AB01`
+// String() returns the fingerprint in the "human friendly" format, for example
+// `AB01 AB01 AB01 AB01 AB01  AB01 AB01 AB01 AB01 AB01`
+
+func (f Fingerprint) String() string {
+	f.assertIsSet()
+	b := f.fingerprintBytes
+
+	return fmt.Sprintf(
+		"%0X %0X %0X %0X %0X  %0X %0X %0X %0X %0X",
+		b[0:2], b[2:4], b[4:6], b[6:8], b[8:10],
+		b[10:12], b[12:14], b[14:16], b[16:18], b[18:20],
+	)
+}
+
+// Return the fingerprint as uppercase hex (20 bytes, 40 characters) without
+// spaces, for example:
+// `AB01AB01AB01AB01AB01AB01AB01AB01AB01AB01`
+
+func (f Fingerprint) Hex() string {
+	f.assertIsSet()
+	b := f.fingerprintBytes
+
+	return fmt.Sprintf("%0X", b)
+}
+
+func (f Fingerprint) Bytes() [20]byte {
+	f.assertIsSet()
+	return f.fingerprintBytes
+}
+
+func (f Fingerprint) IsSet() bool {
+	return f.isSet
+
+}
+
+func (f Fingerprint) assertIsSet() {
+	if !f.IsSet() {
+		panic(fmt.Errorf("Fingerprint.String() called when fingerprint hasn't been set."))
+	}
+}

--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -51,6 +51,14 @@ func MustParse(fp string) Fingerprint {
 	return result
 }
 
+// FromBytes takes 20 bytes and returns a Fingerprint.
+func FromBytes(bytes [20]byte) Fingerprint {
+	return Fingerprint{
+		fingerprintBytes: bytes,
+		isSet:            true,
+	}
+}
+
 // Return a human-friendly version of the fingerprint, which should be a 40
 // character hex string.
 // `AB01 AB01 AB01 AB01 AB01  AB01 AB01 AB01 AB01 AB01`

--- a/fingerprint/fingerprint_test.go
+++ b/fingerprint/fingerprint_test.go
@@ -84,6 +84,21 @@ func TestFingerprint(t *testing.T) {
 		})
 	}
 
+	t.Run("FromBytes function", func(t *testing.T) {
+
+		fp := FromBytes(exampleFingerprintBytes)
+		if !fp.IsSet() {
+			t.Fatalf("FromBytes did not set IsSet=true")
+		}
+
+		expected := "A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517"
+		got := fp.String()
+
+		if expected != got {
+			t.Errorf("expected String='%s', got='%s'", expected, got)
+		}
+	})
+
 	t.Run("Hex method", func(t *testing.T) {
 		fp := MustParse("A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517")
 		expected := "A999B7498D1A8DC473E53C92309F635DAD1B5517"
@@ -116,7 +131,7 @@ func TestFingerprint(t *testing.T) {
 
 	t.Run("Bytes method", func(t *testing.T) {
 		fp := MustParse("A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517")
-		expected := [20]byte{0xA9, 0x99, 0xB7, 0x49, 0x8D, 0x1A, 0x8D, 0xC4, 0x73, 0xE5, 0x3C, 0x92, 0x30, 0x9F, 0x63, 0x5D, 0xAD, 0x1B, 0x55, 0x17}
+		expected := exampleFingerprintBytes
 		got := fp.Bytes()
 
 		if expected != got {
@@ -125,3 +140,5 @@ func TestFingerprint(t *testing.T) {
 	})
 
 }
+
+var exampleFingerprintBytes = [20]byte{0xA9, 0x99, 0xB7, 0x49, 0x8D, 0x1A, 0x8D, 0xC4, 0x73, 0xE5, 0x3C, 0x92, 0x30, 0x9F, 0x63, 0x5D, 0xAD, 0x1B, 0x55, 0x17}

--- a/fingerprint/fingerprint_test.go
+++ b/fingerprint/fingerprint_test.go
@@ -1,0 +1,127 @@
+package fingerprint
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFingerprint(t *testing.T) {
+	var tests = []struct {
+		inputString       string
+		expectedOutput    string
+		shouldReturnError bool
+	}{
+		{
+			"A999B7498D1A8DC473E53C92309F635DAD1B5517",
+			"A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517",
+			false,
+		},
+		{
+			"A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517",
+			"A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517",
+			false,
+		},
+		{
+			`0xA999B7498D1A8DC473E53C92309F635DAD1B5517`,
+			"A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517",
+			false,
+		},
+		{
+			"a999b7498d1a8dc473e53c92309f635dad1b5517",
+			"A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517",
+			false,
+		},
+		{
+			"DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFD",
+			"",
+			true, // error: too long
+		},
+		{
+			"DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEE",
+			"",
+			true, // error: too long
+		},
+		{
+			"DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFG",
+			"",
+			true, // error, contains bad character G
+		},
+		{
+			"",
+			"",
+			true, // error, empty
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Fingerprint.FromString(%v)", test.inputString), func(t *testing.T) {
+			fingerprint, err := Parse(test.inputString)
+
+			var gotError bool = err != nil
+
+			if gotError != test.shouldReturnError {
+				t.Errorf("expected shouldReturnError=%v, got err=%v", test.shouldReturnError, err)
+			}
+
+			if test.shouldReturnError {
+				if err == nil {
+					t.Errorf("expected shouldReturnError=%v, got err=%v", test.shouldReturnError, err)
+				}
+
+			} else {
+
+				if err != nil {
+					t.Fatalf("expected shouldReturnError=%v, got err=%v", test.shouldReturnError, err)
+				}
+
+				gotOutput := fingerprint.String()
+
+				if test.expectedOutput != gotOutput {
+					t.Errorf("expected output='%s', got='%s'", test.expectedOutput, gotOutput)
+				}
+			}
+
+		})
+	}
+
+	t.Run("Hex method", func(t *testing.T) {
+		fp := MustParse("A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517")
+		expected := "A999B7498D1A8DC473E53C92309F635DAD1B5517"
+		got := fp.Hex()
+
+		if expected != got {
+			t.Errorf("expected Hex='%s', got='%s'", expected, got)
+		}
+	})
+
+	t.Run("IsSet method (when set)", func(t *testing.T) {
+		fp := MustParse("A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517")
+		expected := true
+		got := fp.IsSet()
+
+		if expected != got {
+			t.Errorf("expected IsSet()='%v', got='%v'", expected, got)
+		}
+	})
+
+	t.Run("IsSet method (not set)", func(t *testing.T) {
+		var fp Fingerprint
+		expected := false
+		got := fp.IsSet()
+
+		if expected != got {
+			t.Errorf("expected IsSet()='%v', got='%v'", expected, got)
+		}
+	})
+
+	t.Run("Bytes method", func(t *testing.T) {
+		fp := MustParse("A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517")
+		expected := [20]byte{0xA9, 0x99, 0xB7, 0x49, 0x8D, 0x1A, 0x8D, 0xC4, 0x73, 0xE5, 0x3C, 0x92, 0x30, 0x9F, 0x63, 0x5D, 0xAD, 0x1B, 0x55, 0x17}
+		got := fp.Bytes()
+
+		if expected != got {
+			t.Errorf("expected Bytes='%v', got='%v'", expected, got)
+		}
+	})
+
+}

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -197,7 +197,7 @@ func keyCreate() exitCode {
 	fmt.Printf(" > gpg --list-keys '%s'\n", email)
 
 	db := database.New(fluidkeysDirectory)
-	db.RecordFingerprintImportedIntoGnuPG(generateJob.pgpKey.Fingerprint.String())
+	db.RecordFingerprintImportedIntoGnuPG(generateJob.pgpKey.Fingerprint())
 	return 0
 }
 

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -197,7 +197,7 @@ func keyCreate() exitCode {
 	fmt.Printf(" > gpg --list-keys '%s'\n", email)
 
 	db := database.New(fluidkeysDirectory)
-	db.RecordFingerprintImportedIntoGnuPG(generateJob.pgpKey.FingerprintString())
+	db.RecordFingerprintImportedIntoGnuPG(generateJob.pgpKey.Fingerprint.String())
 	return 0
 }
 

--- a/fluidkeys/main_test.go
+++ b/fluidkeys/main_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/fluidkeys/fluidkeys/colour"
+	"github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/gpgwrapper"
 )
 
@@ -107,7 +108,7 @@ func TestPromptForWhichGpgKey(t *testing.T) {
 	t.Run("prints a correctly formatted secret key", func(t *testing.T) {
 		secretKeyListings := []gpgwrapper.SecretKeyListing{
 			gpgwrapper.SecretKeyListing{
-				Fingerprint: "BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB",
+				Fingerprint: fingerprint.MustParse("BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB"),
 				Uids: []string{
 					"Chat Wannamaker<chat2@example.com>",
 					"Chat Rulez<chat3@example.com>",
@@ -133,7 +134,7 @@ func TestPromptForWhichGpgKey(t *testing.T) {
 }
 
 var exampleSecretKey = gpgwrapper.SecretKeyListing{
-	Fingerprint: "BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB",
+	Fingerprint: fingerprint.MustParse("BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB"),
 	Uids: []string{
 		"Chat Wannamaker<chat2@example.com>",
 		"Chat Rulez<chat3@example.com>",

--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 const GpgPath = "gpg2"
@@ -32,7 +34,7 @@ type SecretKeyListing struct {
 	// Fingerprint is the human-readable format of the fingerprint of the
 	// primary key, for example:
 	// `AB01 AB01 AB01 AB01 AB01  AB01 AB01 AB01 AB01 AB01`
-	Fingerprint string
+	Fingerprint fingerprint.Fingerprint
 
 	// Uids is a list of UTF-8 user ID strings as defined in
 	// https://tools.ietf.org/html/rfc4880#section-5.11

--- a/gpgwrapper/gpgwrapper_test.go
+++ b/gpgwrapper/gpgwrapper_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 func TestParseGPGOutputVersion(t *testing.T) {
@@ -116,7 +118,7 @@ func TestListSecretKeys(t *testing.T) {
 	}
 
 	expectedKey := SecretKeyListing{
-		Fingerprint: "C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6",
+		Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
 		Uids:        []string{"test@example.com"},
 		Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
 	}
@@ -137,7 +139,7 @@ func TestParseListSecretKeys(t *testing.T) {
 		}
 
 		expectedFirst := SecretKeyListing{
-			Fingerprint: "A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517",
+			Fingerprint: fingerprint.MustParse("A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517"),
 			Created:     time.Date(2014, 10, 31, 21, 34, 34, 0, time.UTC), // 31 October 2014 21:34:34
 			Uids: []string{
 				"Paul Michael Furley <paul@paulfurley.com>",
@@ -146,7 +148,7 @@ func TestParseListSecretKeys(t *testing.T) {
 		}
 
 		expectedSecond := SecretKeyListing{
-			Fingerprint: "B79F 0840 DEF1 2EBB A72F  F72D 7327 A44C 2157 A758",
+			Fingerprint: fingerprint.MustParse("B79F 0840 DEF1 2EBB A72F  F72D 7327 A44C 2157 A758"),
 			Created:     time.Date(2018, 9, 4, 16, 15, 46, 0, time.UTC), // Tue Sep  4 17:15:46 BST 2018
 			Uids:        []string{"<paul@fluidkeys.com>"},
 		}
@@ -179,62 +181,6 @@ func TestParseListSecretKeys(t *testing.T) {
 			t.Fatalf("expected 0 secret keys, got %d: %v", len(result), result)
 		}
 	})
-}
-
-func TestParseFingerprint(t *testing.T) {
-	var tests = []struct {
-		inputString       string
-		expectedOutput    string
-		shouldReturnError bool
-	}{
-		{
-			"A999B7498D1A8DC473E53C92309F635DAD1B5517",
-			"A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517",
-			false,
-		},
-		{
-			"a999b7498d1a8dc473e53c92309f635dad1b5517",
-			"A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517",
-			false,
-		},
-		{
-			"DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFD",
-			"",
-			true, // error: too long
-		},
-		{
-			"DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEE",
-			"",
-			true, // error: too long
-		},
-		{
-			"DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFG",
-			"",
-			true, // error, contains bad character G
-		},
-		{
-			"",
-			"",
-			true, // error, empty
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("parseFingerprint(%v)", test.inputString), func(t *testing.T) {
-			gotOutput, err := parseFingerprint(test.inputString)
-
-			var gotError bool = err != nil
-
-			if gotError != test.shouldReturnError {
-				t.Errorf("expected shouldReturnError=%v, got err=%v", test.shouldReturnError, err)
-			}
-
-			if test.expectedOutput != gotOutput {
-				t.Errorf("expected output='%s', got='%s'", test.expectedOutput, gotOutput)
-			}
-
-		})
-	}
 }
 
 func TestParseTimestamp(t *testing.T) {

--- a/gpgwrapper/parser.go
+++ b/gpgwrapper/parser.go
@@ -2,10 +2,11 @@ package gpgwrapper
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 // Parse the output of --with-colons --list-secret keys and return only valid
@@ -101,13 +102,13 @@ func (p *listSecretKeysParser) handleFingerprintLine(cols []string) {
 		return
 	}
 
-	if p.partialKey.Fingerprint != "" {
+	if p.partialKey.Fingerprint.IsSet() {
 		// We've already got a fingerprint for this key, so this is
 		// probably a fingerprint for a subkey, which we're not
 		// interested in
 		return
 	}
-	fingerprint, err := parseFingerprint(cols[9])
+	fingerprint, err := fingerprint.Parse(cols[9])
 	if err != nil {
 		return
 	}
@@ -135,7 +136,7 @@ func (p *listSecretKeysParser) handleUidLine(cols []string) {
 // we need to check that the temporary key is complete and put it on Keys.
 
 func (p *listSecretKeysParser) addPartialKeyToList() {
-	if p.partialKey != nil && p.partialKey.Fingerprint != "" && len(p.partialKey.Uids) > 0 {
+	if p.partialKey != nil && p.partialKey.Fingerprint.IsSet() && len(p.partialKey.Uids) > 0 {
 		p.keys = append(p.keys, *p.partialKey)
 	}
 	p.partialKey = nil
@@ -148,26 +149,6 @@ func parseTimestamp(utcTimestamp string) (*time.Time, error) {
 	}
 	resultTime := time.Unix(seconds, 0).UTC()
 	return &resultTime, nil
-}
-
-// Return a human-friendly version of the fingerprint, which should be a 40
-// character hex string. Accepts fingerprints with spaces, uppercase, lowercase
-// but always returns the format:
-// `AB01 AB01 AB01 AB01 AB01  AB01 AB01 AB01 AB01 AB01`
-
-func parseFingerprint(fp string) (string, error) {
-	expectedPattern := `^[A-Fa-f0-9 ]{40}$`
-	if matched, err := regexp.MatchString(expectedPattern, fp); !matched || err != nil {
-		return "", fmt.Errorf("fingerprint doesn't match pattern '%v', err=%v", expectedPattern, err)
-	}
-
-	withoutSpaces := strings.Replace(fp, " ", "", -1)
-	f := strings.ToUpper(withoutSpaces)
-
-	return fmt.Sprintf(
-		"%s %s %s %s %s  %s %s %s %s %s",
-		f[0:4], f[4:8], f[8:12], f[12:16], f[16:20],
-		f[20:24], f[24:28], f[28:32], f[32:36], f[36:40]), nil
 }
 
 // unquoteColons undoes GnuPG's quoting which is used to prevent fields breaking

--- a/pgpkey/pgpkey.go
+++ b/pgpkey/pgpkey.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fluidkeys/crypto/openpgp"
 	"github.com/fluidkeys/crypto/openpgp/armor"
 	"github.com/fluidkeys/crypto/openpgp/packet"
+	"github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 const (
@@ -168,7 +169,7 @@ func (key *PgpKey) Slug() (string, error) {
 		"%s-%s-%s",
 		dateString,
 		emailSlug,
-		key.FingerprintString(),
+		key.Fingerprint().Hex(),
 	), nil
 }
 
@@ -191,8 +192,8 @@ func (key *PgpKey) Email() (string, error) {
 	return emails[0], nil
 }
 
-func (key *PgpKey) FingerprintString() string {
-	return fmt.Sprintf("%X", key.PrimaryKey.Fingerprint)
+func (key *PgpKey) Fingerprint() fingerprint.Fingerprint {
+	return fingerprint.FromBytes(key.PrimaryKey.Fingerprint)
 }
 
 func slugify(textToSlugify string) (slugified string) {

--- a/pgpkey/pgpkey_test.go
+++ b/pgpkey/pgpkey_test.go
@@ -56,7 +56,7 @@ func TestFingerprintMethod(t *testing.T) {
 	pgpKey := loadExamplePgpKey(t)
 
 	t.Run("test PgpKey.FingerprintString() returns the right string", func(t *testing.T) {
-		slug := pgpKey.FingerprintString()
+		slug := pgpKey.Fingerprint().Hex()
 		assertEqual(t, "0C10C4A26E9B1B46E713C8D2BEBF0628DAFF9F4B", slug)
 	})
 }


### PR DESCRIPTION
This Fingerprint parses and outputs the numerous valid formats of an OpenPGP
key fingerprint:

* 20 bytes: {0xA9, 0x99, 0xB7, 0x49, 0x8D, 0x1A, 0x8D, 0xC4, 0x73, 0xE5, 0x3C, 0x92, 0x30, 0x9F, 0x63, 0x5D, 0xAD, 0x1B, 0x55, 0x17}
* hex string: `A999B7498D1A8DC473E53C92309F635DAD1B5517`
* hex string: `0xA999B7498D1A8DC473E53C92309F635DAD1B5517`
* human "friendly" string: `A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517`

This PR also replaces numerous uses of `string` with `Fingerprint`.

@idrysdale thanks for doing 90% of the work on database.go. The trick was to
stop trying to Json marshal / unmarshal a Fingerprint class, and rather define
that as a string:

* Parse it with [fingerprint.Parse](https://github.com/fluidkeys/fluidkeys/commit/4ad33e933780be783b76e4906784d72e14b1b5dd#diff-a8d1aea5cc21c9a6122f8091d2aba940R86)

* Format it with [fp.Hex](https://github.com/fluidkeys/fluidkeys/commit/4ad33e933780be783b76e4906784d72e14b1b5dd#diff-a8d1aea5cc21c9a6122f8091d2aba940R54)