### PR TITLE
fingerprint: Fix bug with leading `0x`

### DIFF
--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -27,7 +27,7 @@ func Parse(fp string) (Fingerprint, error) {
 		return nilFingerprint, fmt.Errorf("fingerprint doesn't match pattern '%v', err=%v", expectedPattern, err)
 	}
 
-	withoutLeading0x := strings.TrimLeft(withoutSpaces, "0x")
+	withoutLeading0x := strings.TrimPrefix(withoutSpaces, "0x")
 
 	bytes, err := hex.DecodeString(withoutLeading0x)
 	if err != nil {

--- a/fingerprint/fingerprint_test.go
+++ b/fingerprint/fingerprint_test.go
@@ -27,6 +27,11 @@ func TestFingerprint(t *testing.T) {
 			false,
 		},
 		{
+			`0C10 C4A2 6E9B 1B46 E713  C8D2 BEBF 0628 DAFF 9F4B`,
+			`0C10 C4A2 6E9B 1B46 E713  C8D2 BEBF 0628 DAFF 9F4B`,
+			false,
+		},
+		{
 			"a999b7498d1a8dc473e53c92309f635dad1b5517",
 			"A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517",
 			false,


### PR DESCRIPTION
`strings.TrimLeft` trims *any* of `0x` so it breaks keys starting with 0

`strings.TrimPrefix` trims *the exact* `0x`, which is what we want.