### PR TITLE
Introduce keytableprinter.FormatKeyWarningLines

### DIFF
--- a/colour/colour.go
+++ b/colour/colour.go
@@ -132,3 +132,7 @@ func White(message string) string {
 func Yellow(message string) string {
 	return FgYellow + message + Reset
 }
+
+func Grey(message string) string {
+	return Bright + FgBlack + message + Reset
+}

--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -1,0 +1,58 @@
+package keytableprinter
+
+import (
+	"fmt"
+
+	"github.com/fluidkeys/fluidkeys/colour"
+	"github.com/fluidkeys/fluidkeys/status"
+)
+
+// FormatKeyWarningLines takes a status.KeyWarning and returns an array of
+// human friendly messages coloured appropriately for printing to the
+// terminal.
+func FormatKeyWarningLines(warning status.KeyWarning) []string {
+	switch warning.(type) {
+
+	case status.DueForRotation:
+		return []string{colour.Warn("Due for rotation 🔄")}
+
+	case status.OverdueForRotation:
+		warnings := []string{
+			colour.Red("Overdue for rotation ⏰"),
+		}
+		var additionalMessage string
+		switch days := warning.(status.OverdueForRotation).DaysUntilExpiry; days {
+		case 0:
+			additionalMessage = "Expires today!"
+		case 1:
+			additionalMessage = "Expires tomorrow!"
+		default:
+			additionalMessage = fmt.Sprintf("Expires in %d days!", days)
+		}
+		return append(warnings, colour.Red(additionalMessage))
+
+	case status.NoExpiry:
+		return []string{colour.Red("No expiry date set 📅")}
+
+	case status.LongExpiry:
+		return []string{colour.Warn("Expiry date too far off 📅")}
+
+	case status.Expired:
+		var message string
+		switch days := warning.(status.Expired).DaysSinceExpiry; days {
+		case 0:
+			message = "Expired today ⚰️"
+		case 1:
+			message = "Expired yesterday ⚰️"
+		case 2, 3, 4, 5, 6, 7, 8, 9:
+			message = fmt.Sprintf("Expired %d days ago ⚰️", days)
+		default:
+			message = "Expired"
+		}
+		return []string{colour.Grey(message)}
+
+	default:
+		// TODO: log this but silently swallow the error
+		return []string{}
+	}
+}

--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -14,7 +14,7 @@ func FormatKeyWarningLines(warning status.KeyWarning) []string {
 	switch warning.(type) {
 
 	case status.DueForRotation:
-		return []string{colour.Warn("Due for rotation 🔄")}
+		return []string{colour.Yellow("Due for rotation 🔄")}
 
 	case status.OverdueForRotation:
 		warnings := []string{
@@ -35,7 +35,7 @@ func FormatKeyWarningLines(warning status.KeyWarning) []string {
 		return []string{colour.Red("No expiry date set 📅")}
 
 	case status.LongExpiry:
-		return []string{colour.Warn("Expiry date too far off 📅")}
+		return []string{colour.Yellow("Expiry date too far off 📅")}
 
 	case status.Expired:
 		var message string

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -1,0 +1,93 @@
+package keytableprinter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+	"github.com/fluidkeys/fluidkeys/colour"
+	"github.com/fluidkeys/fluidkeys/status"
+)
+
+func TestFormatKeyWarningLines(t *testing.T) {
+	var tests = []struct {
+		warning        status.KeyWarning
+		expectedOutput []string
+	}{
+		{
+			status.DueForRotation{},
+			[]string{
+				colour.Warn("Due for rotation 🔄"),
+			},
+		},
+		{
+			status.OverdueForRotation{DaysUntilExpiry: 5},
+			[]string{
+				colour.Red("Overdue for rotation ⏰"),
+				colour.Red("Expires in 5 days!"),
+			},
+		},
+		{
+			status.OverdueForRotation{DaysUntilExpiry: 1},
+			[]string{
+				colour.Red("Overdue for rotation ⏰"),
+				colour.Red("Expires tomorrow!"),
+			},
+		},
+		{
+			status.OverdueForRotation{DaysUntilExpiry: 0},
+			[]string{
+				colour.Red("Overdue for rotation ⏰"),
+				colour.Red("Expires today!"),
+			},
+		},
+		{
+			status.NoExpiry{},
+			[]string{
+				colour.Red("No expiry date set 📅"),
+			},
+		},
+		{
+			status.LongExpiry{},
+			[]string{
+				colour.Warn("Expiry date too far off 📅"),
+			},
+		},
+		{
+			status.Expired{DaysSinceExpiry: 0},
+			[]string{
+				colour.Grey("Expired today ⚰️"),
+			},
+		},
+		{
+			status.Expired{DaysSinceExpiry: 1},
+			[]string{
+				colour.Grey("Expired yesterday ⚰️"),
+			},
+		},
+		{
+			status.Expired{DaysSinceExpiry: 9},
+			[]string{
+				colour.Grey("Expired 9 days ago ⚰️"),
+			},
+		},
+		{
+			status.Expired{DaysSinceExpiry: 10},
+			[]string{
+				colour.Grey("Expired"),
+			},
+		},
+		{
+			nil,
+			[]string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("for status %v", test.warning), func(t *testing.T) {
+			gotOutput := FormatKeyWarningLines(test.warning)
+
+			assert.AssertEqualSliceOfStrings(t, test.expectedOutput, gotOutput)
+		})
+	}
+}

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -17,7 +17,7 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		{
 			status.DueForRotation{},
 			[]string{
-				colour.Warn("Due for rotation 🔄"),
+				colour.Yellow("Due for rotation 🔄"),
 			},
 		},
 		{
@@ -50,7 +50,7 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		{
 			status.LongExpiry{},
 			[]string{
-				colour.Warn("Expiry date too far off 📅"),
+				colour.Yellow("Expiry date too far off 📅"),
 			},
 		},
 		{


### PR DESCRIPTION
FormatKeyWarningLines takes a status.KeyWarning and returns an array of human friendly messages coloured appropriately for printing to the terminal.