### PR TITLE
Show warnings in key list table

### DIFF
--- a/assert/equality.go
+++ b/assert/equality.go
@@ -33,3 +33,19 @@ func AssertEqualSliceOfStrings(t *testing.T, expected, got []string) {
 	}
 
 }
+
+// AssertEqualSliceOfInts compares two slices of ints and calls t.Fatalf
+// with a message if they differ.
+func AssertEqualSliceOfInts(t *testing.T, expected, got []int) {
+	t.Helper()
+	if len(expected) != len(got) {
+		t.Fatalf("expected length %d, got %d. expected: %v, got: %v",
+			len(expected), len(got), expected, got)
+	}
+	for i := range expected {
+		if expected[i] != got[i] {
+			t.Fatalf("expected[%d] differs, expected '%d', got '%d'", i, expected[i], got[i])
+		}
+	}
+
+}

--- a/colour/colour.go
+++ b/colour/colour.go
@@ -136,3 +136,34 @@ func Yellow(message string) string {
 func Grey(message string) string {
 	return Bright + FgBlack + message + Reset
 }
+
+// StripAllColourCodes strips all the ANSI colour codes from a string
+func StripAllColourCodes(message string) string {
+	message = strings.Replace(message, Reset, "", -1)
+	message = strings.Replace(message, Bright, "", -1)
+	message = strings.Replace(message, Dim, "", -1)
+	message = strings.Replace(message, Underscore, "", -1)
+	message = strings.Replace(message, Blink, "", -1)
+	message = strings.Replace(message, Reverse, "", -1)
+	message = strings.Replace(message, Hidden, "", -1)
+
+	message = strings.Replace(message, FgBlack, "", -1)
+	message = strings.Replace(message, FgRed, "", -1)
+	message = strings.Replace(message, FgGreen, "", -1)
+	message = strings.Replace(message, FgYellow, "", -1)
+	message = strings.Replace(message, FgBlue, "", -1)
+	message = strings.Replace(message, FgMagenta, "", -1)
+	message = strings.Replace(message, FgCyan, "", -1)
+	message = strings.Replace(message, FgWhite, "", -1)
+
+	message = strings.Replace(message, BgBlack, "", -1)
+	message = strings.Replace(message, BgRed, "", -1)
+	message = strings.Replace(message, BgGreen, "", -1)
+	message = strings.Replace(message, BgYellow, "", -1)
+	message = strings.Replace(message, BgBlue, "", -1)
+	message = strings.Replace(message, BgMagenta, "", -1)
+	message = strings.Replace(message, BgCyan, "", -1)
+	message = strings.Replace(message, BgWhite, "", -1)
+
+	return message
+}

--- a/colour/colour_test.go
+++ b/colour/colour_test.go
@@ -1,0 +1,36 @@
+package colour
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStripAllColourCodes(t *testing.T) {
+	var tests = []struct {
+		inputString    string
+		expectedOutput string
+	}{
+		{
+			"23",
+			"23",
+		},
+		{
+			"Hello",
+			"Hello",
+		},
+		{
+			LightBlue("Hello"),
+			"Hello",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("for string '%v'", test.inputString), func(t *testing.T) {
+			gotOutput := StripAllColourCodes(test.inputString)
+
+			if gotOutput != test.expectedOutput {
+				t.Fatalf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
+			}
+		})
+	}
+}

--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -9,7 +9,7 @@ import (
 )
 
 func keyWarningLines(key pgpkey.PgpKey) []string {
-	keyWarnings, _ := status.GetKeyWarnings(key)
+	keyWarnings := status.GetKeyWarnings(key)
 	keyWarningLines := []string{}
 	for _, keyWarning := range keyWarnings {
 		keyWarningLines = append(keyWarningLines, formatKeyWarningLines(keyWarning)...)

--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -4,8 +4,18 @@ import (
 	"fmt"
 
 	"github.com/fluidkeys/fluidkeys/colour"
+	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/fluidkeys/fluidkeys/status"
 )
+
+func keyWarningLines(key pgpkey.PgpKey) []string {
+	keyWarnings, _ := status.GetKeyWarnings(key)
+	keyWarningLines := []string{}
+	for _, keyWarning := range keyWarnings {
+		keyWarningLines = append(keyWarningLines, FormatKeyWarningLines(keyWarning)...)
+	}
+	return keyWarningLines
+}
 
 // FormatKeyWarningLines takes a status.KeyWarning and returns an array of
 // human friendly messages coloured appropriately for printing to the

--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -12,7 +12,7 @@ func keyWarningLines(key pgpkey.PgpKey) []string {
 	keyWarnings, _ := status.GetKeyWarnings(key)
 	keyWarningLines := []string{}
 	for _, keyWarning := range keyWarnings {
-		keyWarningLines = append(keyWarningLines, FormatKeyWarningLines(keyWarning)...)
+		keyWarningLines = append(keyWarningLines, formatKeyWarningLines(keyWarning)...)
 	}
 	return keyWarningLines
 }
@@ -20,7 +20,7 @@ func keyWarningLines(key pgpkey.PgpKey) []string {
 // FormatKeyWarningLines takes a status.KeyWarning and returns an array of
 // human friendly messages coloured appropriately for printing to the
 // terminal.
-func FormatKeyWarningLines(warning status.KeyWarning) []string {
+func formatKeyWarningLines(warning status.KeyWarning) []string {
 	switch warning.(type) {
 
 	case status.DueForRotation:

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -85,7 +85,7 @@ func TestFormatKeyWarningLines(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("for status %v", test.warning), func(t *testing.T) {
-			gotOutput := FormatKeyWarningLines(test.warning)
+			gotOutput := formatKeyWarningLines(test.warning)
 
 			assert.AssertEqualSliceOfStrings(t, test.expectedOutput, gotOutput)
 		})

--- a/keytableprinter/keytableprinter.go
+++ b/keytableprinter/keytableprinter.go
@@ -2,94 +2,179 @@ package keytableprinter
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/fluidkeys/fluidkeys/colour"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 )
 
-const gutter = "  "
+type column = []string
+type row = []string
 
-var headers = [3]string{
-	"Email address",
-	"Created",
-	"Next rotation",
+const gutter = "  "
+const divider = "---"
+
+var header = row{
+	colour.Info("Email address"),
+	colour.Info("Created"),
+	colour.Info("Status"),
 }
+
+var placeholderDividerRow = row{divider, divider, divider}
 
 func Print(keys []pgpkey.PgpKey) {
-	fmt.Printf("%s\n", makeTable(keys))
+	rows := makeTableRows(keys)
+	rowStrings := makeStringsFromRows(rows)
+	for _, rowString := range rowStrings {
+		fmt.Println(rowString)
+	}
 }
 
-func makeTable(keys []pgpkey.PgpKey) string {
-	var table string
-	table += fmt.Sprintf("%s\n", colour.LightBlue(makeHeader(columnWidths(keys))))
-	table += fmt.Sprintf("%s\n", makeHorizontalUnderlines(columnWidths(keys)))
+func makeTableRows(keys []pgpkey.PgpKey) []row {
+	var rows []row
+	rows = append(rows, header)
+	rows = append(rows, placeholderDividerRow)
+	rows = append(rows, makeRowsForKeys(keys)...)
+	return rows
+}
 
+// makeRowsForKeys takes a slice of PgpKeys and returns a slice of rows
+// representing the emails, creation time and warning lines associated for
+// each key.
+// e.g ->   [['jane@example.com', '12 Jan 1998', 'Due for rotation',
+//           ['jane@work.com', '', 'Another warning']]
+// It adds a dividing line between each key
+func makeRowsForKeys(keys []pgpkey.PgpKey) []row {
+	var allRows []row
 	for _, key := range keys {
-		emails := key.Emails(true)
-		if len(emails) == 0 {
-			continue // skip this key
+		columns := []column{
+			key.Emails(true),
+			[]string{key.PrimaryKey.CreationTime.Format("2 Jan 2006")},
+			keyWarningLines(key),
 		}
-		firstEmail := emails[0]
-		table += fmt.Sprintf("%-*s%s", columnWidths(keys)[0], firstEmail, gutter)
-		table += fmt.Sprintf("%-*s", columnWidths(keys)[1], key.PrimaryKey.CreationTime.Format("2 Jan 2006"))
-		table += fmt.Sprintf("\n")
-		for _, email := range emails[1:] {
-			table += fmt.Sprintf("%v\n", email)
-		}
-
-		table += fmt.Sprintf("%s\n", makeHorizontalUnderlines(columnWidths(keys)))
+		keyRows := makeRowsFromColumns(columns)
+		allRows = append(allRows, keyRows...)
+		allRows = append(allRows, placeholderDividerRow)
 	}
-	return table
+	return allRows
 }
 
-// makeHeader returns a string representing the header with the appropriate
-// spacing to match the column widths provided, e.g.
-// 'Email address          Created     Next rotation'
-func makeHeader(columnWidths [3]int) string {
-	var header string
-	for column, value := range headers {
-		header += fmt.Sprintf("%-*s%s", columnWidths[column], value, gutter)
-	}
-	return fmt.Sprintf("%s", strings.TrimSuffix(header, gutter))
-}
+// makeRows takes a slice of columns, and returns a slice of rows.
+// It pads out any of the shorter columns with empty cells.
+// e.g.  Columns  : ["Jim", "Jane", "Fi"], ["1", "2"]
+//       => Rows  : [["Jim", "1"], ["Jane", "2"], ["Fi", ""]]
+func makeRowsFromColumns(columns []column) []row {
+	var rows []row
 
-// columnWidths returns the widths of each column in characters
-func columnWidths(keys []pgpkey.PgpKey) [3]int {
-	var columnWidths [3]int
-
-	// Set column widths to header widths
-	for index, headerColumn := range headers {
-		columnWidths[index] = len(headerColumn)
+	columnLengths := make([]int, len(columns))
+	for i, column := range columns {
+		columnLengths[i] = len(column)
 	}
 
-	// Check if column widths need to be extended for cell content
-	for _, key := range keys {
-		for _, email := range key.Identities {
-			columnWidths[0] = max(columnWidths[0], len(email.Name))
+	totalRows := maxInSlice(columnLengths)
+	var lengthenedColumns []column
+
+	for _, column := range columns {
+		lengthenedColumn := lengthenWithEmptyCells(column, totalRows)
+		lengthenedColumns = append(lengthenedColumns, lengthenedColumn)
+	}
+
+	for rowCounter := 0; rowCounter < totalRows; rowCounter++ {
+		var row row
+		for _, column := range lengthenedColumns {
+			row = append(row, column[rowCounter])
 		}
-		columnWidths[1] = max(columnWidths[1], len(key.PrimaryKey.CreationTime.Format("2 Jan 2006")))
-		// TODO: check on rotation date cell when implemented
+		rows = append(rows, row)
 	}
 
-	return columnWidths
+	return rows
 }
 
-// makeHorizontalUnderlines takes an array of integers and for each integer it
-// prints a horizontal line equivalent to it's length, followed by a gutter.
-// eg [3, 2, 5] => '───  ──  ─────'
-func makeHorizontalUnderlines(columnWidths [3]int) string {
-	var underlines string
-	for _, columnWidth := range columnWidths {
-		underlines += fmt.Sprintf("%s%s", strings.Repeat("─", columnWidth), gutter)
+// lengthenWithEmptyCells takes a column, fills it with blank cells such
+// that it becomes the required length and returns this new column.
+func lengthenWithEmptyCells(column column, requiredLength int) column {
+	missingCells := requiredLength - len(column)
+	for i := 0; i < missingCells; i++ {
+		column = append(column, "")
 	}
-	return strings.TrimSuffix(underlines, gutter)
+	return column
+}
+
+// makeStringsFromRows takes a slice of rows and coverts it into a slice of
+// strings, padding out the space between the values appropriately.
+// e.g. ["Jane", "4", "Sheffield"], -> "Jane     4   Sheffield",
+//      ["Gillian", "23", "Hull"]      "Gillian  23  Hull     "
+func makeStringsFromRows(rows []row) []string {
+	var rowStrings []string
+	maxColumnWidths := getColumnWidths(rows)
+
+	for _, row := range rows {
+		var rowString string
+		for columnIndex, value := range row {
+			if value == divider {
+				rowString += makeDividerString(maxColumnWidths[columnIndex])
+			} else {
+				rowString += makeCellString(value, maxColumnWidths[columnIndex])
+			}
+		}
+		rowString = strings.TrimSuffix(rowString, gutter)
+		rowStrings = append(rowStrings, rowString)
+	}
+
+	return rowStrings
+}
+
+// makeDividerString substitutes in our placeholder '---' with horizontal
+// strings equal to the specified length. For example: 8 -> '────────'
+func makeDividerString(length int) string {
+	return fmt.Sprintf("%s%s", strings.Repeat("─", length), gutter)
+}
+
+func makeCellString(value string, cellLength int) string {
+	return fmt.Sprintf(
+		"%s%s%s",
+		value,
+		// This is more complicated since we have colours on strings
+		strings.Repeat(" ", cellLength-len(colour.StripAllColourCodes(value))),
+		gutter,
+	)
+}
+
+// getColumnWidths takes a slice of rows and then finds the length of the
+// longest value in each column.
+func getColumnWidths(rows []row) []int {
+	maxColumnWidths := make(map[int]int) // Column index -> Maximum width
+
+	for _, row := range rows {
+		for columnIndex, value := range row {
+			maxColumnWidths[columnIndex] = max(
+				maxColumnWidths[columnIndex],
+				len(colour.StripAllColourCodes(value)),
+			)
+		}
+	}
+
+	var result []int
+	for columnIndex := 0; columnIndex < len(rows[0]); columnIndex++ {
+		result = append(result, maxColumnWidths[columnIndex])
+	}
+	return result
+}
+
+// maxInSlice returns the larget int in the slice
+func maxInSlice(values []int) int {
+	sliceNumbers := sort.IntSlice(values)
+	sort.Sort(sliceNumbers)
+	largest := sliceNumbers[len(sliceNumbers)-1]
+	return largest
 }
 
 // max returns the larger of x or y.
-func max(x, y int) int {
+func max(x int, y int) int {
 	if x < y {
 		return y
+	} else {
+		return x
 	}
-	return x
 }

--- a/keytableprinter/keytableprinter.go
+++ b/keytableprinter/keytableprinter.go
@@ -144,6 +144,9 @@ func makeCellString(value string, cellLength int) string {
 // getColumnWidths takes a slice of rows and then finds the length of the
 // longest value in each column.
 func getColumnWidths(rows []row) []int {
+	if len(rows) == 0 {
+		return []int{}
+	}
 	maxColumnWidths := make(map[int]int) // Column index -> Maximum width
 
 	for _, row := range rows {

--- a/keytableprinter/keytableprinter_test.go
+++ b/keytableprinter/keytableprinter_test.go
@@ -90,16 +90,27 @@ func TestMakeStringsFromRows(t *testing.T) {
 }
 
 func TestGetColumnWidths(t *testing.T) {
-	rows := []row{
-		row{"1234", "12", "123"},
-		row{"12", "123456", "1"},
-		row{"123", "123", "12"},
-	}
+	t.Run("with sensible rows", func(t *testing.T) {
+		rows := []row{
+			row{"1234", "12", "123"},
+			row{"12", "123456", "1"},
+			row{"123", "123", "12"},
+		}
 
-	want := []int{4, 6, 3}
-	got := getColumnWidths(rows)
+		want := []int{4, 6, 3}
+		got := getColumnWidths(rows)
 
-	assert.AssertEqualSliceOfInts(t, want, got)
+		assert.AssertEqualSliceOfInts(t, want, got)
+	})
+
+	t.Run("with empty rows", func(t *testing.T) {
+		rows := []row{}
+
+		want := []int{}
+		got := getColumnWidths(rows)
+
+		assert.AssertEqualSliceOfInts(t, want, got)
+	})
 }
 
 func TestMaxInSlice(t *testing.T) {

--- a/keytableprinter/keytableprinter_test.go
+++ b/keytableprinter/keytableprinter_test.go
@@ -5,7 +5,25 @@ import (
 
 	"github.com/fluidkeys/fluidkeys/assert"
 	"github.com/fluidkeys/fluidkeys/colour"
+	"github.com/fluidkeys/fluidkeys/exampledata"
+	"github.com/fluidkeys/fluidkeys/pgpkey"
 )
+
+func TestMakeTableRows(t *testing.T) {
+	pgpKey, err := pgpkey.LoadFromArmoredPublicKey(exampledata.ExamplePublicKey2)
+	if err != nil {
+		t.Fatalf("failed to load example PgpKey: %v", err)
+	}
+
+	t.Run("with example pgp key", func(t *testing.T) {
+		makeTableRows([]pgpkey.PgpKey{*pgpKey})
+	})
+
+	t.Run("with empty slice of keys", func(t *testing.T) {
+		makeTableRows([]pgpkey.PgpKey{})
+	})
+
+}
 
 func TestMakeRowsFromColumns(t *testing.T) {
 	columns := []column{


### PR DESCRIPTION
Bit of a biggie this. Introducing the warnings opened a bit of a can of worms, since now we have columns of different lengths for keys.

I ended up refactoring `keytableprinter` to deal with this, which also resulted in some neater tests.