### PR TITLE
Simplify StripAllColourCodes

### DIFF
--- a/colour/colour.go
+++ b/colour/colour.go
@@ -139,31 +139,9 @@ func Grey(message string) string {
 
 // StripAllColourCodes strips all the ANSI colour codes from a string
 func StripAllColourCodes(message string) string {
-	message = strings.Replace(message, Reset, "", -1)
-	message = strings.Replace(message, Bright, "", -1)
-	message = strings.Replace(message, Dim, "", -1)
-	message = strings.Replace(message, Underscore, "", -1)
-	message = strings.Replace(message, Blink, "", -1)
-	message = strings.Replace(message, Reverse, "", -1)
-	message = strings.Replace(message, Hidden, "", -1)
-
-	message = strings.Replace(message, FgBlack, "", -1)
-	message = strings.Replace(message, FgRed, "", -1)
-	message = strings.Replace(message, FgGreen, "", -1)
-	message = strings.Replace(message, FgYellow, "", -1)
-	message = strings.Replace(message, FgBlue, "", -1)
-	message = strings.Replace(message, FgMagenta, "", -1)
-	message = strings.Replace(message, FgCyan, "", -1)
-	message = strings.Replace(message, FgWhite, "", -1)
-
-	message = strings.Replace(message, BgBlack, "", -1)
-	message = strings.Replace(message, BgRed, "", -1)
-	message = strings.Replace(message, BgGreen, "", -1)
-	message = strings.Replace(message, BgYellow, "", -1)
-	message = strings.Replace(message, BgBlue, "", -1)
-	message = strings.Replace(message, BgMagenta, "", -1)
-	message = strings.Replace(message, BgCyan, "", -1)
-	message = strings.Replace(message, BgWhite, "", -1)
+	for _, colourCode := range AllColourCodes {
+		message = strings.Replace(message, colourCode, "", -1)
+	}
 
 	return message
 }

--- a/colour/constants.go
+++ b/colour/constants.go
@@ -27,3 +27,31 @@ const (
 	BgCyan    = "\x1b[46m"
 	BgWhite   = "\x1b[47m"
 )
+
+var AllColourCodes = []string{
+	Reset,
+	Bright,
+	Dim,
+	Underscore,
+	Blink,
+	Reverse,
+	Hidden,
+
+	FgBlack,
+	FgRed,
+	FgGreen,
+	FgYellow,
+	FgBlue,
+	FgMagenta,
+	FgCyan,
+	FgWhite,
+
+	BgBlack,
+	BgRed,
+	BgGreen,
+	BgYellow,
+	BgBlue,
+	BgMagenta,
+	BgCyan,
+	BgWhite,
+}


### PR DESCRIPTION
This way, it'll be harder for the two lists of colour codes to go out of
sync (e.g. adding a colour code to `constants.go` and not realising it
*also* must be added to `StripAllColourCodes`)