### PR TITLE
Pass getDaysUntilExpiry expiry, not rotation due date

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -52,7 +52,7 @@ func GetKeyWarnings(key pgpkey.PgpKey) []KeyWarning {
 
 		} else if isOverdueForRotation(nextRotation, now) {
 			warning := OverdueForRotation{
-				DaysUntilExpiry: getDaysUntilExpiry(nextRotation, now),
+				DaysUntilExpiry: getDaysUntilExpiry(*expiry, now),
 			}
 			warnings = append(warnings, warning)
 


### PR DESCRIPTION
Fixes this bug:
https://trello.com/c/toE2lfhK/163-getdaysuntilexpiry-expiry-has-already-passed