### PR TITLE
Refactor KeyWarning

### DIFF
--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -26,6 +26,9 @@ func keyWarningLines(key pgpkey.PgpKey, keyWarnings []status.KeyWarning) []strin
 func formatKeyWarningLines(warning status.KeyWarning) []string {
 	switch warning.Type {
 
+	case status.NoValidEncryptionSubkey:
+		return []string{colour.Yellow("Missing encryption subkey")}
+
 	case status.PrimaryKeyDueForRotation, status.SubkeyDueForRotation:
 		return []string{colour.Yellow("Due for rotation 🔄")}
 

--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -26,10 +26,10 @@ func keyWarningLines(key pgpkey.PgpKey, keyWarnings []status.KeyWarning) []strin
 func formatKeyWarningLines(warning status.KeyWarning) []string {
 	switch warning.Type {
 
-	case status.PrimaryKeyDueForRotation:
+	case status.PrimaryKeyDueForRotation, status.SubkeyDueForRotation:
 		return []string{colour.Yellow("Due for rotation 🔄")}
 
-	case status.PrimaryKeyOverdueForRotation:
+	case status.PrimaryKeyOverdueForRotation, status.SubkeyOverdueForRotation:
 		warnings := []string{
 			colour.Red("Overdue for rotation ⏰"),
 		}
@@ -47,7 +47,12 @@ func formatKeyWarningLines(warning status.KeyWarning) []string {
 	case status.PrimaryKeyNoExpiry:
 		return []string{colour.Red("No expiry date set 📅")}
 
-	case status.PrimaryKeyLongExpiry:
+	case status.SubkeyNoExpiry:
+		return []string{colour.Red("Subkey never expires 📅")}
+
+	case status.PrimaryKeyLongExpiry, status.SubkeyLongExpiry:
+		// This message might be confusing if the primary key has a
+		// reasonable expiry, but the subkey has a long one.
 		return []string{colour.Yellow("Expiry date too far off 📅")}
 
 	case status.PrimaryKeyExpired:

--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -24,17 +24,17 @@ func keyWarningLines(key pgpkey.PgpKey, keyWarnings []status.KeyWarning) []strin
 // human friendly messages coloured appropriately for printing to the
 // terminal.
 func formatKeyWarningLines(warning status.KeyWarning) []string {
-	switch warning.(type) {
+	switch warning.Type {
 
-	case status.DueForRotation:
+	case status.PrimaryKeyDueForRotation:
 		return []string{colour.Yellow("Due for rotation 🔄")}
 
-	case status.OverdueForRotation:
+	case status.PrimaryKeyOverdueForRotation:
 		warnings := []string{
 			colour.Red("Overdue for rotation ⏰"),
 		}
 		var additionalMessage string
-		switch days := warning.(status.OverdueForRotation).DaysUntilExpiry; days {
+		switch days := warning.DaysUntilExpiry; days {
 		case 0:
 			additionalMessage = "Expires today!"
 		case 1:
@@ -44,15 +44,15 @@ func formatKeyWarningLines(warning status.KeyWarning) []string {
 		}
 		return append(warnings, colour.Red(additionalMessage))
 
-	case status.NoExpiry:
+	case status.PrimaryKeyNoExpiry:
 		return []string{colour.Red("No expiry date set 📅")}
 
-	case status.LongExpiry:
+	case status.PrimaryKeyLongExpiry:
 		return []string{colour.Yellow("Expiry date too far off 📅")}
 
-	case status.Expired:
+	case status.PrimaryKeyExpired:
 		var message string
-		switch days := warning.(status.Expired).DaysSinceExpiry; days {
+		switch days := warning.DaysSinceExpiry; days {
 		case 0:
 			message = "Expired today ⚰️"
 		case 1:

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -105,6 +105,12 @@ func TestFormatKeyWarningLines(t *testing.T) {
 			},
 		},
 		{
+			status.KeyWarning{Type: status.NoValidEncryptionSubkey},
+			[]string{
+				colour.Yellow("Missing encryption subkey"),
+			},
+		},
+		{
 			status.KeyWarning{}, // unspecified type
 			[]string{},
 		},

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -23,6 +23,12 @@ func TestFormatKeyWarningLines(t *testing.T) {
 			},
 		},
 		{
+			status.KeyWarning{Type: status.SubkeyDueForRotation},
+			[]string{
+				colour.Yellow("Due for rotation 🔄"),
+			},
+		},
+		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 5},
 			[]string{
 				colour.Red("Overdue for rotation ⏰"),
@@ -44,13 +50,32 @@ func TestFormatKeyWarningLines(t *testing.T) {
 			},
 		},
 		{
+			status.KeyWarning{Type: status.SubkeyOverdueForRotation, DaysUntilExpiry: 5},
+			[]string{
+				colour.Red("Overdue for rotation ⏰"),
+				colour.Red("Expires in 5 days!"),
+			},
+		},
+		{
 			status.KeyWarning{Type: status.PrimaryKeyNoExpiry},
 			[]string{
 				colour.Red("No expiry date set 📅"),
 			},
 		},
 		{
+			status.KeyWarning{Type: status.SubkeyNoExpiry},
+			[]string{
+				colour.Red("Subkey never expires 📅"),
+			},
+		},
+		{
 			status.KeyWarning{Type: status.PrimaryKeyLongExpiry},
+			[]string{
+				colour.Yellow("Expiry date too far off 📅"),
+			},
+		},
+		{
+			status.KeyWarning{Type: status.SubkeyLongExpiry},
 			[]string{
 				colour.Yellow("Expiry date too far off 📅"),
 			},

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -17,70 +17,70 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		expectedOutput []string
 	}{
 		{
-			status.DueForRotation{},
+			status.KeyWarning{Type: status.PrimaryKeyDueForRotation},
 			[]string{
 				colour.Yellow("Due for rotation 🔄"),
 			},
 		},
 		{
-			status.OverdueForRotation{DaysUntilExpiry: 5},
+			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 5},
 			[]string{
 				colour.Red("Overdue for rotation ⏰"),
 				colour.Red("Expires in 5 days!"),
 			},
 		},
 		{
-			status.OverdueForRotation{DaysUntilExpiry: 1},
+			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 1},
 			[]string{
 				colour.Red("Overdue for rotation ⏰"),
 				colour.Red("Expires tomorrow!"),
 			},
 		},
 		{
-			status.OverdueForRotation{DaysUntilExpiry: 0},
+			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 0},
 			[]string{
 				colour.Red("Overdue for rotation ⏰"),
 				colour.Red("Expires today!"),
 			},
 		},
 		{
-			status.NoExpiry{},
+			status.KeyWarning{Type: status.PrimaryKeyNoExpiry},
 			[]string{
 				colour.Red("No expiry date set 📅"),
 			},
 		},
 		{
-			status.LongExpiry{},
+			status.KeyWarning{Type: status.PrimaryKeyLongExpiry},
 			[]string{
 				colour.Yellow("Expiry date too far off 📅"),
 			},
 		},
 		{
-			status.Expired{DaysSinceExpiry: 0},
+			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 0},
 			[]string{
 				colour.Grey("Expired today ⚰️"),
 			},
 		},
 		{
-			status.Expired{DaysSinceExpiry: 1},
+			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 1},
 			[]string{
 				colour.Grey("Expired yesterday ⚰️"),
 			},
 		},
 		{
-			status.Expired{DaysSinceExpiry: 9},
+			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 9},
 			[]string{
 				colour.Grey("Expired 9 days ago ⚰️"),
 			},
 		},
 		{
-			status.Expired{DaysSinceExpiry: 10},
+			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 10},
 			[]string{
 				colour.Grey("Expired"),
 			},
 		},
 		{
-			nil,
+			status.KeyWarning{}, // unspecified type
 			[]string{},
 		},
 	}

--- a/status/keywarning.go
+++ b/status/keywarning.go
@@ -1,0 +1,38 @@
+package status
+
+type WarningType int
+
+const (
+	PrimaryKeyDueForRotation     WarningType = 1
+	PrimaryKeyOverdueForRotation WarningType = 2
+	PrimaryKeyExpired            WarningType = 3
+	PrimaryKeyNoExpiry           WarningType = 4
+	PrimaryKeyLongExpiry         WarningType = 5
+)
+
+type KeyWarning struct {
+	Type WarningType
+
+	DaysUntilExpiry uint
+	DaysSinceExpiry uint
+}
+
+func (w KeyWarning) String() string {
+	switch w.Type {
+	case PrimaryKeyDueForRotation:
+		return "PrimaryKeyDueForRotation"
+
+	case PrimaryKeyOverdueForRotation:
+		return "PrimaryKeyOverdueForRotation"
+
+	case PrimaryKeyExpired:
+		return "PrimaryKeyExpired"
+
+	case PrimaryKeyNoExpiry:
+		return "PrimaryKeyNoExpiry"
+
+	case PrimaryKeyLongExpiry:
+		return "PrimaryKeyLongExpiry"
+
+	return "KeyWarning[unknown]"
+}

--- a/status/keywarning.go
+++ b/status/keywarning.go
@@ -1,5 +1,9 @@
 package status
 
+import (
+	"fmt"
+)
+
 type WarningType int
 
 const (
@@ -8,11 +12,18 @@ const (
 	PrimaryKeyExpired            WarningType = 3
 	PrimaryKeyNoExpiry           WarningType = 4
 	PrimaryKeyLongExpiry         WarningType = 5
+
+	NoValidEncryptionSubkey  WarningType = 6
+	SubkeyDueForRotation     WarningType = 7
+	SubkeyOverdueForRotation WarningType = 8
+	SubkeyNoExpiry           WarningType = 9
+	SubkeyLongExpiry         WarningType = 10
 )
 
 type KeyWarning struct {
 	Type WarningType
 
+	SubkeyId        uint64
 	DaysUntilExpiry uint
 	DaysSinceExpiry uint
 }
@@ -34,5 +45,25 @@ func (w KeyWarning) String() string {
 	case PrimaryKeyLongExpiry:
 		return "PrimaryKeyLongExpiry"
 
+	case NoValidEncryptionSubkey:
+		return "NoValidEncryptionSubkey"
+
+	case SubkeyDueForRotation:
+		return addSubkeyId("SubkeyDueForRotation", w.SubkeyId)
+
+	case SubkeyOverdueForRotation:
+		return addSubkeyId("SubkeyOverdueForRotation", w.SubkeyId)
+
+	case SubkeyNoExpiry:
+		return addSubkeyId("SubkeyNoExpiry", w.SubkeyId)
+
+	case SubkeyLongExpiry:
+		return addSubkeyId("SubkeyLongExpiry", w.SubkeyId)
+	}
+
 	return "KeyWarning[unknown]"
+}
+
+func addSubkeyId(warningName string, subkeyId uint64) string {
+	return fmt.Sprintf("%s [0x%X]", warningName, subkeyId)
 }


### PR DESCRIPTION
* Change KeyWarning interface to a KeyWarning struct with a WarningType field

* Rename:
  - DueForRotation     -> PrimaryKeyDueForRotation
  - OverdueForRotation -> PrimaryKeyOverdueForRotatin
  - Expired            -> PrimaryKeyExpired
  - NoExpiry           -> PrimaryKeyNoExpiry
  - LongExpiry         -> PrimaryKeyLongExpiry

* Add Subkey warning types
  - NoValidEncryptionSubkey
  - SubkeyDueForRotation
  - SubkeyOverdueForRotation
  - SubkeyNoExpiry
  - SubkeyLongExpiry

Note that the subkey warnings stray a bit from our design document: we haven't
really decided whether to hide or suppress any mention of subkeys...

Note that this currently causes duplication where the primary key and subkey
both produce the same warning message.