### PR TITLE
add MakeActionsFromKeyWarnings() function and tests

### DIFF
--- a/status/actions.go
+++ b/status/actions.go
@@ -1,7 +1,6 @@
 package status
 
 import (
-	//	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"fmt"
 	"time"
 )

--- a/status/actions_test.go
+++ b/status/actions_test.go
@@ -1,0 +1,127 @@
+package status
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestMakeActionsForSingleWarning(t *testing.T) {
+	now := time.Date(2018, 6, 15, 0, 0, 0, 0, time.UTC)
+	nextExpiry := nextExpiryTime(now)
+
+	var tests = []struct {
+		warningType     WarningType
+		subkeyId        uint64
+		expectedActions []KeyAction
+	}{
+		{
+			PrimaryKeyDueForRotation,
+			0,
+			[]KeyAction{
+				ModifyPrimaryKeyExpiry{ValidUntil: nextExpiry},
+			},
+		},
+		{
+			PrimaryKeyDueForRotation,
+			0,
+			[]KeyAction{
+				ModifyPrimaryKeyExpiry{ValidUntil: nextExpiry},
+			},
+		},
+		{
+			PrimaryKeyOverdueForRotation,
+			0,
+			[]KeyAction{
+				ModifyPrimaryKeyExpiry{ValidUntil: nextExpiry},
+			},
+		},
+		{
+			PrimaryKeyExpired,
+			0,
+			[]KeyAction{
+				ModifyPrimaryKeyExpiry{ValidUntil: nextExpiry},
+			},
+		},
+		{
+			PrimaryKeyNoExpiry,
+			0,
+			[]KeyAction{
+				ModifyPrimaryKeyExpiry{ValidUntil: nextExpiry},
+			},
+		},
+		{
+			PrimaryKeyLongExpiry,
+			0,
+			[]KeyAction{
+				ModifyPrimaryKeyExpiry{ValidUntil: nextExpiry},
+			},
+		},
+		{
+			NoValidEncryptionSubkey,
+			0,
+			[]KeyAction{
+				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
+			},
+		},
+		{
+			SubkeyDueForRotation,
+			9999,
+			[]KeyAction{
+				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
+				RevokeSubkey{SubkeyId: 9999},
+			},
+		},
+		{
+			SubkeyOverdueForRotation,
+			9999,
+			[]KeyAction{
+				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
+				RevokeSubkey{SubkeyId: 9999},
+			},
+		},
+		{
+			SubkeyNoExpiry,
+			9999,
+			[]KeyAction{
+				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
+				RevokeSubkey{SubkeyId: 9999},
+			},
+		},
+		{
+			SubkeyLongExpiry,
+			9999,
+			[]KeyAction{
+				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
+				RevokeSubkey{SubkeyId: 9999},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		warning := KeyWarning{
+			Type:     test.warningType,
+			SubkeyId: test.subkeyId,
+		}
+
+		t.Run(fmt.Sprintf("%s subkey=%v", warning, test.subkeyId), func(t *testing.T) {
+			gotActions := makeActionsFromSingleWarning(warning, now)
+			fmt.Sprintf("gotActions: %v\n", gotActions)
+			assertActionsEqual(t, test.expectedActions, gotActions)
+		})
+	}
+}
+
+func assertActionsEqual(t *testing.T, expected []KeyAction, got []KeyAction) {
+	t.Helper()
+	if len(expected) != len(got) {
+		t.Fatalf("expected %d actions, got %d. expected: %v, got: %v", len(expected), len(got), expected, got)
+	}
+
+	for i := range expected {
+		if expected[i] != got[i] {
+			t.Fatalf("expected[%d] = %v, got[%d] = %v", i, expected[i], i, got[i])
+		}
+
+	}
+}

--- a/status/keyactions.go
+++ b/status/keyactions.go
@@ -1,0 +1,60 @@
+package status
+
+import (
+	"fmt"
+	"github.com/fluidkeys/fluidkeys/pgpkey"
+	"time"
+)
+
+// ModifyPrimaryKeyExpiry means the self signature of the key will be refreshed
+// with a future expiry date
+type ModifyPrimaryKeyExpiry struct {
+	KeyAction
+
+	ValidUntil time.Time
+}
+
+// ModifyPrimaryKeyExpiry creates a new self signature on each user ID with
+// ValidUntil
+func (a ModifyPrimaryKeyExpiry) Enact(key *pgpkey.PgpKey) error {
+	return key.UpdateExpiryForAllUserIds(a.ValidUntil)
+}
+
+func (a ModifyPrimaryKeyExpiry) String() string {
+	return fmt.Sprintf("ModifyPrimaryKeyExpiry [to %v]", a.ValidUntil)
+}
+
+// CreateNewEncryptionSubkey describes creating a new subkey with the given
+// ValidUntil expiry time.
+type CreateNewEncryptionSubkey struct {
+	KeyAction
+
+	ValidUntil time.Time
+}
+
+// Enact calls PgpKey.CreateNewEncryptionSubkey()
+func (a CreateNewEncryptionSubkey) Enact(key *pgpkey.PgpKey) error {
+	return key.CreateNewEncryptionSubkey(a.ValidUntil)
+}
+
+func (a CreateNewEncryptionSubkey) String() string {
+	return fmt.Sprintf("CreateNewEncryptionSubkey[expires %s]", a.ValidUntil.Format("2006-01-02"))
+}
+
+// RevokeSubkey indicates that the given SubkeyId will be revoked
+type RevokeSubkey struct {
+	KeyAction
+
+	SubkeyId uint64
+}
+
+// Enact calls PgpKey.RevokeSubkey, passing in SubkeyId
+func (a RevokeSubkey) Enact(key *pgpkey.PgpKey) error {
+	return key.RevokeSubkey(a.SubkeyId)
+}
+func (a RevokeSubkey) String() string { return fmt.Sprintf("RevokeSubkey[0x%X]", a.SubkeyId) }
+
+type KeyAction interface {
+	String() string
+	Enact(*pgpkey.PgpKey) error
+}


### PR DESCRIPTION
This is the core of the key rotation code - for a given `KeyWarning`, define
a `KeyAction` that remedies that situation.

For discussion: should a subkey that's overdue for rotation be revoked (and
another subkey created) or should its expiry be shortened?