### PR TITLE
PgpKey.Generate: set expiry according to (new) policy

### DIFF
--- a/assert/equality.go
+++ b/assert/equality.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"testing"
+	"time"
 )
 
 // EqualSliceOfStrings tells whether a and b contain the same elements.
@@ -46,6 +47,17 @@ func AssertEqualSliceOfInts(t *testing.T, expected, got []int) {
 		if expected[i] != got[i] {
 			t.Fatalf("expected[%d] differs, expected '%d', got '%d'", i, expected[i], got[i])
 		}
+	}
+
+}
+
+// AssertEqualTime compares two times and calls t.Fatalf. Different timezones
+// are treated as different times, even if they correspond to the same moment
+// in time.
+func AssertEqualTimes(t *testing.T, expected time.Time, got time.Time) {
+	t.Helper()
+	if expected != got {
+		t.Fatalf("expected %v, got %v", expected, got)
 	}
 
 }

--- a/pgpkey/pgpkey.go
+++ b/pgpkey/pgpkey.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fluidkeys/crypto/openpgp/armor"
 	"github.com/fluidkeys/crypto/openpgp/packet"
 	"github.com/fluidkeys/fluidkeys/fingerprint"
+	"github.com/fluidkeys/fluidkeys/policy"
 )
 
 const (
@@ -95,7 +96,6 @@ func generateInsecure(email string, creationTime time.Time) (*PgpKey, error) {
 func generateKeyOfSize(email string, rsaBits int, creationTime time.Time) (*PgpKey, error) {
 	config := Config{}
 	config.Config.RSABits = rsaBits
-	config.Expiry = time.Hour * 24 * 60 // 60 days
 	config.Config.Time = func() time.Time { return creationTime }
 
 	name, comment := "", ""
@@ -105,7 +105,7 @@ func generateKeyOfSize(email string, rsaBits int, creationTime time.Time) (*PgpK
 		return nil, err
 	}
 
-	keyLifetimeSeconds := uint32(config.Expiry.Seconds())
+	keyLifetimeSeconds := uint32(policy.NextExpiryTime(creationTime).Sub(creationTime).Seconds())
 
 	for _, id := range entity.Identities {
 		id.SelfSignature.CreationTime = creationTime

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,0 +1,60 @@
+package policy
+
+import (
+	"time"
+)
+
+const (
+	tenDays       time.Duration = time.Duration(time.Hour * 24 * 10)
+	thirtyDays    time.Duration = time.Duration(time.Hour * 24 * 30)
+	fortyFiveDays time.Duration = time.Duration(time.Hour * 24 * 45)
+)
+
+// NextExpiryTime returns the expiry time in UTC, according to the policy:
+//     "30 days after the 1st of the next month"
+// for example, if today is 15th September, nextExpiryTime would return
+// 1st October + 30 days
+func NextExpiryTime(now time.Time) time.Time {
+	return firstOfNextMonth(now).Add(thirtyDays).In(time.UTC)
+}
+
+// NextRotation returns 30 days before the earliest expiry time on
+// the key.
+// If the key doesn't expire, it returns nil.
+func NextRotation(expiry time.Time) time.Time {
+	return expiry.Add(-thirtyDays)
+}
+
+// IsExpiryTooLong returns true if the expiry is too far in the future.
+//
+// It's important not to raise this warning for expiries that we've set
+// ourselves.
+// We use `NextExpiryTime` such that when we set an expiry date it's *exactly*
+// on the cusp of being too long, and can only get shorter after that point.
+func IsExpiryTooLong(expiry time.Time, now time.Time) bool {
+	latestAcceptableExpiry := NextExpiryTime(now)
+	return expiry.After(latestAcceptableExpiry)
+}
+
+// IsOverdueForRotation returns true if `now` is more than 10 days after
+// nextRotation
+func IsOverdueForRotation(nextRotation time.Time, now time.Time) bool {
+	overdueTime := nextRotation.Add(tenDays)
+	return overdueTime.Before(now)
+}
+
+// IsDueForRotation returns true if `now` is any time after the key's next
+// rotation time
+func IsDueForRotation(nextRotation time.Time, now time.Time) bool {
+	return nextRotation.Before(now)
+}
+
+func firstOfNextMonth(today time.Time) time.Time {
+	firstOfThisMonth := beginningOfMonth(today)
+	return beginningOfMonth(firstOfThisMonth.Add(fortyFiveDays))
+}
+
+func beginningOfMonth(now time.Time) time.Time {
+	y, m, _ := now.Date()
+	return time.Date(y, m, 1, 0, 0, 0, 0, now.Location()).In(time.UTC)
+}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,0 +1,168 @@
+package policy
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+var (
+	feb1st           = time.Date(2018, 2, 1, 0, 0, 0, 0, time.UTC)
+	march1st         = time.Date(2018, 3, 1, 0, 0, 0, 0, time.UTC)
+	march1stLeapYear = time.Date(2020, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	anotherTimezone = time.FixedZone("UTC+8", 8*60*60)
+)
+
+func TestFirstOfNextMonth(t *testing.T) {
+	var tests = []struct {
+		today          time.Time
+		expectedOutput time.Time
+	}{
+		{
+			time.Date(2018, 1, 1, 18, 0, 0, 0, time.UTC), // start of Jan
+			feb1st,
+		},
+		{
+			time.Date(2018, 1, 15, 18, 0, 0, 0, time.UTC), // middle of Jan
+			feb1st,
+		},
+		{
+			time.Date(2018, 1, 31, 23, 59, 59, 0, time.UTC), // end of Jan
+			feb1st,
+		},
+		{
+			time.Date(2018, 2, 1, 18, 0, 0, 0, time.UTC), // start of Feb
+			march1st,
+		},
+		{
+			time.Date(2018, 2, 15, 18, 0, 0, 0, time.UTC), // middle of Feb
+			march1st,
+		},
+		{
+			time.Date(2018, 2, 28, 23, 59, 59, 0, time.UTC), // end of Feb
+			march1st,
+		},
+		{
+			time.Date(2020, 2, 29, 23, 59, 59, 0, time.UTC), // end of Feb, leap year
+			march1stLeapYear,
+		},
+		{
+			time.Date(2020, 2, 29, 23, 59, 59, 0, time.UTC), // end of Feb, leap year
+			march1stLeapYear,
+		},
+		{
+			time.Date(2018, 2, 15, 12, 0, 0, 0, anotherTimezone), // non-UTC
+			time.Date(2018, 3, 1, 0, 0, 0, 0, time.UTC),          // should convert timezone
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("today = %v", test.today), func(t *testing.T) {
+			gotOutput := firstOfNextMonth(test.today)
+
+			if test.expectedOutput != gotOutput {
+				t.Fatalf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
+			}
+		})
+	}
+}
+
+func TestNextExpiryTime(t *testing.T) {
+
+	var tests = []struct {
+		today          time.Time
+		expectedOutput time.Time
+	}{
+		{
+			time.Date(2018, 1, 1, 18, 0, 0, 0, time.UTC), // start of Jan
+			feb1st.Add(thirtyDays),
+		},
+		{
+			time.Date(2018, 1, 15, 18, 0, 0, 0, time.UTC), // middle of Jan
+			feb1st.Add(thirtyDays),
+		},
+		{
+			time.Date(2018, 1, 31, 23, 59, 59, 0, time.UTC), // end of Jan
+			feb1st.Add(thirtyDays),
+		},
+		{
+			time.Date(2018, 2, 1, 18, 0, 0, 0, time.UTC), // start of Feb
+			march1st.Add(thirtyDays),
+		},
+		{
+			time.Date(2018, 2, 15, 18, 0, 0, 0, time.UTC), // middle of Feb
+			march1st.Add(thirtyDays),
+		},
+		{
+			time.Date(2018, 2, 28, 23, 59, 59, 0, time.UTC), // end of Feb
+			march1st.Add(thirtyDays),
+		},
+		{
+			time.Date(2020, 2, 29, 23, 59, 59, 0, time.UTC), // end of Feb, leap year
+			march1stLeapYear.Add(thirtyDays),
+		},
+		{
+			time.Date(2018, 2, 15, 18, 0, 0, 0, anotherTimezone), // non-UTC
+			time.Date(2018, 3, 31, 0, 0, 0, 0, time.UTC),         // should convert to UTC
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("today = %v", test.today), func(t *testing.T) {
+			gotOutput := NextExpiryTime(test.today)
+
+			if test.expectedOutput != gotOutput {
+				t.Fatalf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
+			}
+		})
+	}
+}
+
+func TestDueOverdueFunctions(t *testing.T) {
+	now := time.Date(2018, 6, 15, 0, 0, 0, 0, time.UTC)
+	rotationInFuture := now.Add(time.Duration(1) * time.Hour)
+	rotationInPast := now.Add(time.Duration(-1) * time.Hour)
+
+	nineDaysInPast := now.Add(time.Duration(-9*24) * time.Hour)
+	tenDaysInPast := now.Add(time.Duration(-10*24) * time.Hour)
+	tenDaysOneSecondInPast := tenDaysInPast.Add(time.Duration(1) * time.Second)
+	elevenDaysInPast := now.Add(time.Duration(-11*24) * time.Hour)
+
+	t.Run("IsDueForRotation with future date", func(t *testing.T) {
+		if IsDueForRotation(rotationInFuture, now) != false {
+			t.Errorf("expected IsDueForRotation(%v, %v) to return false", rotationInFuture, now)
+		}
+	})
+
+	t.Run("IsDueForRotation with past date", func(t *testing.T) {
+		if IsDueForRotation(rotationInPast, now) != true {
+			t.Errorf("expected IsDueForRotation(%v, %v) to return true", rotationInPast, now)
+		}
+	})
+
+	t.Run("IsOverdueForRotation with 9 days", func(t *testing.T) {
+		if IsOverdueForRotation(nineDaysInPast, now) != false {
+			t.Errorf("expected IsOverdueForRotation(%v, %v) to return false", nineDaysInPast, now)
+		}
+	})
+
+	t.Run("IsOverdueForRotation with exactly 10 days", func(t *testing.T) {
+		if IsOverdueForRotation(tenDaysInPast, now) != false {
+			t.Errorf("expected IsOverdueForRotation(%v, %v) to return false", tenDaysInPast, now)
+		}
+	})
+
+	t.Run("IsOverdueForRotation with 10 days + 1 second", func(t *testing.T) {
+		if IsOverdueForRotation(tenDaysOneSecondInPast, now) != false {
+			t.Errorf("expected IsOverdueForRotation(%v, %v) to return false", tenDaysOneSecondInPast, now)
+		}
+	})
+
+	t.Run("IsOverdueForRotation with 11 days", func(t *testing.T) {
+		if IsOverdueForRotation(elevenDaysInPast, now) != true {
+			t.Errorf("expected IsOverdueForRotation(%v, %v) to return true", elevenDaysInPast, now)
+		}
+	})
+
+}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -1,7 +1,6 @@
 package status
 
 import (
-	"fmt"
 	"github.com/fluidkeys/fluidkeys/exampledata"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"testing"
@@ -15,111 +14,6 @@ var (
 
 	anotherTimezone = time.FixedZone("UTC+8", 8*60*60)
 )
-
-func TestFirstOfNextMonth(t *testing.T) {
-	var tests = []struct {
-		today          time.Time
-		expectedOutput time.Time
-	}{
-		{
-			time.Date(2018, 1, 1, 18, 0, 0, 0, time.UTC), // start of Jan
-			feb1st,
-		},
-		{
-			time.Date(2018, 1, 15, 18, 0, 0, 0, time.UTC), // middle of Jan
-			feb1st,
-		},
-		{
-			time.Date(2018, 1, 31, 23, 59, 59, 0, time.UTC), // end of Jan
-			feb1st,
-		},
-		{
-			time.Date(2018, 2, 1, 18, 0, 0, 0, time.UTC), // start of Feb
-			march1st,
-		},
-		{
-			time.Date(2018, 2, 15, 18, 0, 0, 0, time.UTC), // middle of Feb
-			march1st,
-		},
-		{
-			time.Date(2018, 2, 28, 23, 59, 59, 0, time.UTC), // end of Feb
-			march1st,
-		},
-		{
-			time.Date(2020, 2, 29, 23, 59, 59, 0, time.UTC), // end of Feb, leap year
-			march1stLeapYear,
-		},
-		{
-			time.Date(2020, 2, 29, 23, 59, 59, 0, time.UTC), // end of Feb, leap year
-			march1stLeapYear,
-		},
-		{
-			time.Date(2018, 2, 15, 12, 0, 0, 0, anotherTimezone), // non-UTC
-			time.Date(2018, 3, 1, 0, 0, 0, 0, time.UTC),          // should convert timezone
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("today = %v", test.today), func(t *testing.T) {
-			gotOutput := firstOfNextMonth(test.today)
-
-			if test.expectedOutput != gotOutput {
-				t.Fatalf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
-			}
-		})
-	}
-}
-
-func TestNextExpiryTime(t *testing.T) {
-
-	var tests = []struct {
-		today          time.Time
-		expectedOutput time.Time
-	}{
-		{
-			time.Date(2018, 1, 1, 18, 0, 0, 0, time.UTC), // start of Jan
-			feb1st.Add(thirtyDays),
-		},
-		{
-			time.Date(2018, 1, 15, 18, 0, 0, 0, time.UTC), // middle of Jan
-			feb1st.Add(thirtyDays),
-		},
-		{
-			time.Date(2018, 1, 31, 23, 59, 59, 0, time.UTC), // end of Jan
-			feb1st.Add(thirtyDays),
-		},
-		{
-			time.Date(2018, 2, 1, 18, 0, 0, 0, time.UTC), // start of Feb
-			march1st.Add(thirtyDays),
-		},
-		{
-			time.Date(2018, 2, 15, 18, 0, 0, 0, time.UTC), // middle of Feb
-			march1st.Add(thirtyDays),
-		},
-		{
-			time.Date(2018, 2, 28, 23, 59, 59, 0, time.UTC), // end of Feb
-			march1st.Add(thirtyDays),
-		},
-		{
-			time.Date(2020, 2, 29, 23, 59, 59, 0, time.UTC), // end of Feb, leap year
-			march1stLeapYear.Add(thirtyDays),
-		},
-		{
-			time.Date(2018, 2, 15, 18, 0, 0, 0, anotherTimezone), // non-UTC
-			time.Date(2018, 3, 31, 0, 0, 0, 0, time.UTC),         // should convert to UTC
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("today = %v", test.today), func(t *testing.T) {
-			gotOutput := nextExpiryTime(test.today)
-
-			if test.expectedOutput != gotOutput {
-				t.Fatalf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
-			}
-		})
-	}
-}
 
 func TestGetEarliestExpiryTime(t *testing.T) {
 	key, err := pgpkey.LoadFromArmoredPublicKey(exampledata.ExamplePublicKey3)
@@ -154,13 +48,6 @@ func TestDateHelpers(t *testing.T) {
 	now := time.Date(2018, 6, 15, 0, 0, 0, 0, time.UTC)
 	expiryInFuture := now.Add(time.Duration(1) * time.Hour)
 	expiryInPast := now.Add(time.Duration(-1) * time.Hour)
-	rotationInFuture := now.Add(time.Duration(1) * time.Hour)
-	rotationInPast := now.Add(time.Duration(-1) * time.Hour)
-
-	nineDaysInPast := now.Add(time.Duration(-9*24) * time.Hour)
-	tenDaysInPast := now.Add(time.Duration(-10*24) * time.Hour)
-	tenDaysOneSecondInPast := tenDaysInPast.Add(time.Duration(1) * time.Second)
-	elevenDaysInPast := now.Add(time.Duration(-11*24) * time.Hour)
 
 	t.Run("isExpired with past date", func(t *testing.T) {
 		if isExpired(expiryInPast, now) != true {
@@ -172,42 +59,6 @@ func TestDateHelpers(t *testing.T) {
 	t.Run("isExpired with future date", func(t *testing.T) {
 		if isExpired(expiryInFuture, now) != false {
 			t.Errorf("expected isExpired(%v, %v) to return true", expiryInFuture, now)
-		}
-	})
-
-	t.Run("isDueForRotation with future date", func(t *testing.T) {
-		if isDueForRotation(rotationInFuture, now) != false {
-			t.Errorf("expected isDueForRotation(%v, %v) to return false", rotationInFuture, now)
-		}
-	})
-
-	t.Run("isDueForRotation with past date", func(t *testing.T) {
-		if isDueForRotation(rotationInPast, now) != true {
-			t.Errorf("expected isDueForRotation(%v, %v) to return true", rotationInPast, now)
-		}
-	})
-
-	t.Run("isOverdueForRotation with 9 days", func(t *testing.T) {
-		if isOverdueForRotation(nineDaysInPast, now) != false {
-			t.Errorf("expected isOverdueForRotation(%v, %v) to return false", nineDaysInPast, now)
-		}
-	})
-
-	t.Run("isOverdueForRotation with exactly 10 days", func(t *testing.T) {
-		if isOverdueForRotation(tenDaysInPast, now) != false {
-			t.Errorf("expected isOverdueForRotation(%v, %v) to return false", tenDaysInPast, now)
-		}
-	})
-
-	t.Run("isOverdueForRotation with 10 days + 1 second", func(t *testing.T) {
-		if isOverdueForRotation(tenDaysOneSecondInPast, now) != false {
-			t.Errorf("expected isOverdueForRotation(%v, %v) to return false", tenDaysOneSecondInPast, now)
-		}
-	})
-
-	t.Run("isOverdueForRotation with 11 days", func(t *testing.T) {
-		if isOverdueForRotation(elevenDaysInPast, now) != true {
-			t.Errorf("expected isOverdueForRotation(%v, %v) to return true", elevenDaysInPast, now)
 		}
 	})
 


### PR DESCRIPTION
* split status package into status & policy

  status was logically doing 2 things:
  
  1. defining the "policy" e.g. when to rotate keys, define expiry etc 2.
  testing against, and enforcing the policy, e.g. "this key's expiry is too
  long"
  
  I realised this when I tried to point PgpKey.Generate at status'
  NextExpiryTime function and got a circular import[1]
  
  I think what we *actually* want is a separate "policy" package which
  defines the rules, and have status just enforce them. Then, PgpKey can ask
  the policy package for the expiry it should use.
  
  I think the policy package will also be a perfect place to define the
  ciphers, hashes, compression preferences[2]
  
  [1]:
  https://trello.com/c/KfZguoBa/182-when-we-make-a-new-key-set-its-expiry-to-the-next-rotation-time-not-60-days
  [2]:
  https://trello.com/c/5IfrDbky/185-a-newly-generated-key-doesnt-have-any-cipher-hash-or-compression-preferences

* pass creationTime into PgpKey.generateInsecure

  And add tests to check that it's actually used...
  Note that its passed down into `openpgp` inside the `Config` struct