### PR TITLE
Redesign status for key list

### DIFF
--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -30,42 +30,42 @@ func formatKeyWarningLines(warning status.KeyWarning) []string {
 		return []string{colour.Yellow("Missing encryption subkey")}
 
 	case status.PrimaryKeyDueForRotation:
-		return []string{colour.Yellow("Primary key due for rotation 🔄")}
+		return []string{colour.Yellow("Primary key due for rotation")}
 
 	case status.SubkeyDueForRotation:
-		return []string{colour.Yellow(" └─ Subkey due for rotation 🔄")}
+		return []string{colour.Yellow(" └─ Subkey due for rotation")}
 
 	case status.PrimaryKeyOverdueForRotation:
-		warnings := []string{colour.Red("Primary key overdue for rotation ⏰")}
+		warnings := []string{colour.Red("Primary key overdue for rotation")}
 		return append(warnings, colour.Red(countdownUntilExpiry(warning.DaysUntilExpiry, 0)))
 
 	case status.SubkeyOverdueForRotation:
-		warnings := []string{colour.Red(" └─ Subkey overdue for rotation ⏰")}
+		warnings := []string{colour.Red(" └─ Subkey overdue for rotation")}
 		return append(warnings, colour.Red(countdownUntilExpiry(warning.DaysUntilExpiry, 4)))
 
 	case status.PrimaryKeyNoExpiry:
-		return []string{colour.Red("Primary key never expires 📅")}
+		return []string{colour.Red("Primary key never expires")}
 
 	case status.SubkeyNoExpiry:
-		return []string{colour.Red(" └─ Subkey never expires 📅")}
+		return []string{colour.Red(" └─ Subkey never expires")}
 
 	case status.PrimaryKeyLongExpiry:
-		return []string{colour.Yellow("Primary key set to expire too far in the future 🔮")}
+		return []string{colour.Yellow("Primary key set to expire too far in the future")}
 
 	case status.SubkeyLongExpiry:
 		// This message might be confusing if the primary key has a
 		// reasonable expiry, but the subkey has a long one.
-		return []string{colour.Yellow(" └─ Subkey set to expire too far in the future 🔮")}
+		return []string{colour.Yellow(" └─ Subkey set to expire too far in the future")}
 
 	case status.PrimaryKeyExpired:
 		var message string
 		switch days := warning.DaysSinceExpiry; days {
 		case 0:
-			message = "Expired today ⚰️"
+			message = "Expired today"
 		case 1:
-			message = "Expired yesterday ⚰️"
+			message = "Expired yesterday"
 		case 2, 3, 4, 5, 6, 7, 8, 9:
-			message = fmt.Sprintf("Expired %d days ago ⚰️", days)
+			message = fmt.Sprintf("Expired %d days ago", days)
 		default:
 			message = "Expired"
 		}

--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -33,21 +33,21 @@ func formatKeyWarningLines(warning status.KeyWarning) []string {
 		return []string{colour.Yellow("Primary key due for rotation 🔄")}
 
 	case status.SubkeyDueForRotation:
-		return []string{colour.Yellow("Subkey due for rotation 🔄")}
+		return []string{colour.Yellow(" └─ Subkey due for rotation 🔄")}
 
 	case status.PrimaryKeyOverdueForRotation:
 		warnings := []string{colour.Red("Primary key overdue for rotation ⏰")}
-		return append(warnings, colour.Red(countdownUntilExpiry(warning.DaysUntilExpiry)))
+		return append(warnings, colour.Red(countdownUntilExpiry(warning.DaysUntilExpiry, 0)))
 
 	case status.SubkeyOverdueForRotation:
-		warnings := []string{colour.Red("Subkey overdue for rotation ⏰")}
-		return append(warnings, colour.Red(countdownUntilExpiry(warning.DaysUntilExpiry)))
+		warnings := []string{colour.Red(" └─ Subkey overdue for rotation ⏰")}
+		return append(warnings, colour.Red(countdownUntilExpiry(warning.DaysUntilExpiry, 4)))
 
 	case status.PrimaryKeyNoExpiry:
 		return []string{colour.Red("Primary key never expires 📅")}
 
 	case status.SubkeyNoExpiry:
-		return []string{colour.Red("Subkey never expires 📅")}
+		return []string{colour.Red(" └─ Subkey never expires 📅")}
 
 	case status.PrimaryKeyLongExpiry:
 		return []string{colour.Yellow("Primary key set to expire too far in the future 🔮")}
@@ -55,7 +55,7 @@ func formatKeyWarningLines(warning status.KeyWarning) []string {
 	case status.SubkeyLongExpiry:
 		// This message might be confusing if the primary key has a
 		// reasonable expiry, but the subkey has a long one.
-		return []string{colour.Yellow("Subkey set to expire too far in the future 🔮")}
+		return []string{colour.Yellow(" └─ Subkey set to expire too far in the future 🔮")}
 
 	case status.PrimaryKeyExpired:
 		var message string
@@ -77,13 +77,13 @@ func formatKeyWarningLines(warning status.KeyWarning) []string {
 	}
 }
 
-func countdownUntilExpiry(days uint) string {
+func countdownUntilExpiry(days uint, indent uint) string {
 	switch days {
 	case 0:
 		return "Expires today!"
 	case 1:
 		return "Expires tomorrow!"
 	default:
-		return fmt.Sprintf("Expires in %d days!", days)
+		return fmt.Sprintf("%*sExpires in %d days!", indent, "", days)
 	}
 }

--- a/keytableprinter/formatwarnings.go
+++ b/keytableprinter/formatwarnings.go
@@ -29,34 +29,33 @@ func formatKeyWarningLines(warning status.KeyWarning) []string {
 	case status.NoValidEncryptionSubkey:
 		return []string{colour.Yellow("Missing encryption subkey")}
 
-	case status.PrimaryKeyDueForRotation, status.SubkeyDueForRotation:
-		return []string{colour.Yellow("Due for rotation 🔄")}
+	case status.PrimaryKeyDueForRotation:
+		return []string{colour.Yellow("Primary key due for rotation 🔄")}
 
-	case status.PrimaryKeyOverdueForRotation, status.SubkeyOverdueForRotation:
-		warnings := []string{
-			colour.Red("Overdue for rotation ⏰"),
-		}
-		var additionalMessage string
-		switch days := warning.DaysUntilExpiry; days {
-		case 0:
-			additionalMessage = "Expires today!"
-		case 1:
-			additionalMessage = "Expires tomorrow!"
-		default:
-			additionalMessage = fmt.Sprintf("Expires in %d days!", days)
-		}
-		return append(warnings, colour.Red(additionalMessage))
+	case status.SubkeyDueForRotation:
+		return []string{colour.Yellow("Subkey due for rotation 🔄")}
+
+	case status.PrimaryKeyOverdueForRotation:
+		warnings := []string{colour.Red("Primary key overdue for rotation ⏰")}
+		return append(warnings, colour.Red(countdownUntilExpiry(warning.DaysUntilExpiry)))
+
+	case status.SubkeyOverdueForRotation:
+		warnings := []string{colour.Red("Subkey overdue for rotation ⏰")}
+		return append(warnings, colour.Red(countdownUntilExpiry(warning.DaysUntilExpiry)))
 
 	case status.PrimaryKeyNoExpiry:
-		return []string{colour.Red("No expiry date set 📅")}
+		return []string{colour.Red("Primary key never expires 📅")}
 
 	case status.SubkeyNoExpiry:
 		return []string{colour.Red("Subkey never expires 📅")}
 
-	case status.PrimaryKeyLongExpiry, status.SubkeyLongExpiry:
+	case status.PrimaryKeyLongExpiry:
+		return []string{colour.Yellow("Primary key set to expire too far in the future 🔮")}
+
+	case status.SubkeyLongExpiry:
 		// This message might be confusing if the primary key has a
 		// reasonable expiry, but the subkey has a long one.
-		return []string{colour.Yellow("Expiry date too far off 📅")}
+		return []string{colour.Yellow("Subkey set to expire too far in the future 🔮")}
 
 	case status.PrimaryKeyExpired:
 		var message string
@@ -75,5 +74,16 @@ func formatKeyWarningLines(warning status.KeyWarning) []string {
 	default:
 		// TODO: log this but silently swallow the error
 		return []string{}
+	}
+}
+
+func countdownUntilExpiry(days uint) string {
+	switch days {
+	case 0:
+		return "Expires today!"
+	case 1:
+		return "Expires tomorrow!"
+	default:
+		return fmt.Sprintf("Expires in %d days!", days)
 	}
 }

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -19,83 +19,83 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		{
 			status.KeyWarning{Type: status.PrimaryKeyDueForRotation},
 			[]string{
-				colour.Yellow("Primary key due for rotation 🔄"),
+				colour.Yellow("Primary key due for rotation"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyDueForRotation},
 			[]string{
-				colour.Yellow(" └─ Subkey due for rotation 🔄"),
+				colour.Yellow(" └─ Subkey due for rotation"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 5},
 			[]string{
-				colour.Red("Primary key overdue for rotation ⏰"),
+				colour.Red("Primary key overdue for rotation"),
 				colour.Red("Expires in 5 days!"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 1},
 			[]string{
-				colour.Red("Primary key overdue for rotation ⏰"),
+				colour.Red("Primary key overdue for rotation"),
 				colour.Red("Expires tomorrow!"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 0},
 			[]string{
-				colour.Red("Primary key overdue for rotation ⏰"),
+				colour.Red("Primary key overdue for rotation"),
 				colour.Red("Expires today!"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyOverdueForRotation, DaysUntilExpiry: 5},
 			[]string{
-				colour.Red(" └─ Subkey overdue for rotation ⏰"),
+				colour.Red(" └─ Subkey overdue for rotation"),
 				colour.Red("    Expires in 5 days!"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyNoExpiry},
 			[]string{
-				colour.Red("Primary key never expires 📅"),
+				colour.Red("Primary key never expires"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyNoExpiry},
 			[]string{
-				colour.Red(" └─ Subkey never expires 📅"),
+				colour.Red(" └─ Subkey never expires"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyLongExpiry},
 			[]string{
-				colour.Yellow("Primary key set to expire too far in the future 🔮"),
+				colour.Yellow("Primary key set to expire too far in the future"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyLongExpiry},
 			[]string{
-				colour.Yellow(" └─ Subkey set to expire too far in the future 🔮"),
+				colour.Yellow(" └─ Subkey set to expire too far in the future"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 0},
 			[]string{
-				colour.Grey("Expired today ⚰️"),
+				colour.Grey("Expired today"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 1},
 			[]string{
-				colour.Grey("Expired yesterday ⚰️"),
+				colour.Grey("Expired yesterday"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 9},
 			[]string{
-				colour.Grey("Expired 9 days ago ⚰️"),
+				colour.Grey("Expired 9 days ago"),
 			},
 		},
 		{

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -19,47 +19,47 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		{
 			status.KeyWarning{Type: status.PrimaryKeyDueForRotation},
 			[]string{
-				colour.Yellow("Due for rotation 🔄"),
+				colour.Yellow("Primary key due for rotation 🔄"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyDueForRotation},
 			[]string{
-				colour.Yellow("Due for rotation 🔄"),
+				colour.Yellow("Subkey due for rotation 🔄"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 5},
 			[]string{
-				colour.Red("Overdue for rotation ⏰"),
+				colour.Red("Primary key overdue for rotation ⏰"),
 				colour.Red("Expires in 5 days!"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 1},
 			[]string{
-				colour.Red("Overdue for rotation ⏰"),
+				colour.Red("Primary key overdue for rotation ⏰"),
 				colour.Red("Expires tomorrow!"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 0},
 			[]string{
-				colour.Red("Overdue for rotation ⏰"),
+				colour.Red("Primary key overdue for rotation ⏰"),
 				colour.Red("Expires today!"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyOverdueForRotation, DaysUntilExpiry: 5},
 			[]string{
-				colour.Red("Overdue for rotation ⏰"),
+				colour.Red("Subkey overdue for rotation ⏰"),
 				colour.Red("Expires in 5 days!"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyNoExpiry},
 			[]string{
-				colour.Red("No expiry date set 📅"),
+				colour.Red("Primary key never expires 📅"),
 			},
 		},
 		{
@@ -71,13 +71,13 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		{
 			status.KeyWarning{Type: status.PrimaryKeyLongExpiry},
 			[]string{
-				colour.Yellow("Expiry date too far off 📅"),
+				colour.Yellow("Primary key set to expire too far in the future 🔮"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyLongExpiry},
 			[]string{
-				colour.Yellow("Expiry date too far off 📅"),
+				colour.Yellow("Subkey set to expire too far in the future 🔮"),
 			},
 		},
 		{

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -14,22 +14,26 @@ import (
 func TestFormatKeyWarningLines(t *testing.T) {
 	var tests = []struct {
 		warning        status.KeyWarning
+		indent         bool
 		expectedOutput []string
 	}{
 		{
 			status.KeyWarning{Type: status.PrimaryKeyDueForRotation},
+			false,
 			[]string{
 				colour.Yellow("Primary key due for rotation"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyDueForRotation},
+			true,
 			[]string{
 				colour.Yellow(" └─ Subkey due for rotation"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 5},
+			false,
 			[]string{
 				colour.Red("Primary key overdue for rotation"),
 				colour.Red("Expires in 5 days!"),
@@ -37,6 +41,7 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 1},
+			false,
 			[]string{
 				colour.Red("Primary key overdue for rotation"),
 				colour.Red("Expires tomorrow!"),
@@ -44,6 +49,7 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyOverdueForRotation, DaysUntilExpiry: 0},
+			false,
 			[]string{
 				colour.Red("Primary key overdue for rotation"),
 				colour.Red("Expires today!"),
@@ -51,6 +57,7 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyOverdueForRotation, DaysUntilExpiry: 5},
+			true,
 			[]string{
 				colour.Red(" └─ Subkey overdue for rotation"),
 				colour.Red("    Expires in 5 days!"),
@@ -58,67 +65,91 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyNoExpiry},
+			false,
 			[]string{
 				colour.Red("Primary key never expires"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyNoExpiry},
+			true,
 			[]string{
 				colour.Red(" └─ Subkey never expires"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyLongExpiry},
+			false,
 			[]string{
 				colour.Yellow("Primary key set to expire too far in the future"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.SubkeyLongExpiry},
+			true,
 			[]string{
 				colour.Yellow(" └─ Subkey set to expire too far in the future"),
 			},
 		},
 		{
+			status.KeyWarning{Type: status.SubkeyLongExpiry},
+			false,
+			[]string{
+				colour.Yellow("Subkey set to expire too far in the future"),
+			},
+		},
+		{
 			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 0},
+			false,
 			[]string{
 				colour.Grey("Expired today"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 1},
+			false,
 			[]string{
 				colour.Grey("Expired yesterday"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 9},
+			false,
 			[]string{
 				colour.Grey("Expired 9 days ago"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.PrimaryKeyExpired, DaysSinceExpiry: 10},
+			false,
 			[]string{
 				colour.Grey("Expired"),
 			},
 		},
 		{
 			status.KeyWarning{Type: status.NoValidEncryptionSubkey},
+			false,
+			[]string{
+				colour.Yellow("Missing encryption subkey"),
+			},
+		},
+		{
+			status.KeyWarning{Type: status.NoValidEncryptionSubkey},
+			true,
 			[]string{
 				colour.Yellow("Missing encryption subkey"),
 			},
 		},
 		{
 			status.KeyWarning{}, // unspecified type
+			false,
 			[]string{},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("for status %v", test.warning), func(t *testing.T) {
-			gotOutput := formatKeyWarningLines(test.warning)
+			gotOutput := formatKeyWarningLines(test.warning, test.indent)
 
 			assert.AssertEqualSliceOfStrings(t, test.expectedOutput, gotOutput)
 		})

--- a/keytableprinter/formatwarnings_test.go
+++ b/keytableprinter/formatwarnings_test.go
@@ -25,7 +25,7 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		{
 			status.KeyWarning{Type: status.SubkeyDueForRotation},
 			[]string{
-				colour.Yellow("Subkey due for rotation 🔄"),
+				colour.Yellow(" └─ Subkey due for rotation 🔄"),
 			},
 		},
 		{
@@ -52,8 +52,8 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		{
 			status.KeyWarning{Type: status.SubkeyOverdueForRotation, DaysUntilExpiry: 5},
 			[]string{
-				colour.Red("Subkey overdue for rotation ⏰"),
-				colour.Red("Expires in 5 days!"),
+				colour.Red(" └─ Subkey overdue for rotation ⏰"),
+				colour.Red("    Expires in 5 days!"),
 			},
 		},
 		{
@@ -65,7 +65,7 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		{
 			status.KeyWarning{Type: status.SubkeyNoExpiry},
 			[]string{
-				colour.Red("Subkey never expires 📅"),
+				colour.Red(" └─ Subkey never expires 📅"),
 			},
 		},
 		{
@@ -77,7 +77,7 @@ func TestFormatKeyWarningLines(t *testing.T) {
 		{
 			status.KeyWarning{Type: status.SubkeyLongExpiry},
 			[]string{
-				colour.Yellow("Subkey set to expire too far in the future 🔮"),
+				colour.Yellow(" └─ Subkey set to expire too far in the future 🔮"),
 			},
 		},
 		{

--- a/status/keywarning.go
+++ b/status/keywarning.go
@@ -90,6 +90,15 @@ func (w KeyWarning) IsAboutPrimaryKey() bool {
 	return false
 }
 
+func ContainsWarningAboutPrimaryKey(warnings []KeyWarning) bool {
+	for _, warning := range warnings {
+		if warning.IsAboutPrimaryKey() {
+			return true
+		}
+	}
+	return false
+}
+
 func addSubkeyId(warningName string, subkeyId uint64) string {
 	return fmt.Sprintf("%s [0x%X]", warningName, subkeyId)
 }

--- a/status/keywarning.go
+++ b/status/keywarning.go
@@ -7,6 +7,7 @@ import (
 type WarningType int
 
 const (
+	// If you add a type, remember to handle it in all the switch statements.
 	PrimaryKeyDueForRotation     WarningType = 1
 	PrimaryKeyOverdueForRotation WarningType = 2
 	PrimaryKeyExpired            WarningType = 3
@@ -62,6 +63,31 @@ func (w KeyWarning) String() string {
 	}
 
 	return "KeyWarning[unknown]"
+}
+
+func (w KeyWarning) IsAboutSubkey() bool {
+	switch w.Type {
+	case
+		SubkeyDueForRotation,
+		SubkeyOverdueForRotation,
+		SubkeyNoExpiry,
+		SubkeyLongExpiry:
+		return true
+	}
+	return false
+}
+
+func (w KeyWarning) IsAboutPrimaryKey() bool {
+	switch w.Type {
+	case
+		PrimaryKeyDueForRotation,
+		PrimaryKeyOverdueForRotation,
+		PrimaryKeyExpired,
+		PrimaryKeyNoExpiry,
+		PrimaryKeyLongExpiry:
+		return true
+	}
+	return false
 }
 
 func addSubkeyId(warningName string, subkeyId uint64) string {

--- a/status/keywarning_test.go
+++ b/status/keywarning_test.go
@@ -1,0 +1,49 @@
+package status
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestContainsWarningsAboutPrimaryKey(t *testing.T) {
+	var tests = []struct {
+		warnings       []KeyWarning
+		expectedOutput bool
+	}{
+		{
+			[]KeyWarning{
+				KeyWarning{Type: SubkeyOverdueForRotation},
+				KeyWarning{Type: PrimaryKeyLongExpiry},
+			},
+			true,
+		},
+		{
+			[]KeyWarning{
+				KeyWarning{Type: SubkeyOverdueForRotation},
+				KeyWarning{Type: SubkeyLongExpiry},
+			},
+			false,
+		},
+		{
+			[]KeyWarning{
+				KeyWarning{Type: NoValidEncryptionSubkey},
+			},
+			false,
+		},
+		{
+			[]KeyWarning{},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("for warnings %v", test.warnings), func(t *testing.T) {
+			gotOutput := ContainsWarningAboutPrimaryKey(test.warnings)
+
+			if gotOutput != test.expectedOutput {
+				t.Fatalf("expected %v, got %v", test.expectedOutput, gotOutput)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
I've made the warning messages clearer, and now we nest the subkey message lines beneath the primary key messages.

We only Indent subkey warning lines only if primary warning present too.

i.e.:

```
-----------------------------------------------
Primary Key set to expire too far in the future
 └─ Subkey set to expire too far in the future
-----------------------------------------------
```

Subkey warnings remaining unindented if no primary warning present:

```
-----------------------------------------------
Subkey overdue for rotation
-----------------------------------------------
```