### PR TITLE
pgpkey.Generate: set cipher/hash/compression prefs

### DIFF
--- a/assert/equality.go
+++ b/assert/equality.go
@@ -1,9 +1,20 @@
 package assert
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
+
+// assert.Equal aims to test equality of any two objects, and call t.Fatalf
+// if they're not equal
+func Equal(t *testing.T, expected interface{}, got interface{}) {
+	t.Helper()
+
+	if !reflect.DeepEqual(expected, got) {
+		t.Fatalf("expected %v got %v", expected, got)
+	}
+}
 
 // EqualSliceOfStrings tells whether a and b contain the same elements.
 // A nil argument is equivalent to an empty slice.

--- a/pgpkey/pgpkey.go
+++ b/pgpkey/pgpkey.go
@@ -122,6 +122,9 @@ func generateKeyOfSize(email string, rsaBits int, creationTime time.Time) (*PgpK
 	for _, id := range entity.Identities {
 		id.SelfSignature.CreationTime = creationTime
 		id.SelfSignature.KeyLifetimeSecs = &keyLifetimeSeconds
+
+		setSelfSignaturePreferences(id.SelfSignature)
+
 		err := id.SelfSignature.SignUserId(id.UserId.Id, entity.PrimaryKey, entity.PrivateKey, &config.Config)
 		if err != nil {
 			return nil, err
@@ -489,6 +492,12 @@ func isEncryptionSubkeyValid(subkey openpgp.Subkey, now time.Time) bool {
 
 	valid := !isRevoked && createdInThePast && subkey.Sig.FlagsValid && hasEncryptionFlag && inDate
 	return valid
+}
+
+func setSelfSignaturePreferences(selfSignature *packet.Signature) {
+	selfSignature.PreferredSymmetric = policy.AdvertiseCipherPreferences
+	selfSignature.PreferredHash = policy.AdvertiseHashPreferences
+	selfSignature.PreferredCompression = policy.AdvertiseCompressionPreferences
 }
 
 func slugify(textToSlugify string) (slugified string) {

--- a/pgpkey/pgpkey_test.go
+++ b/pgpkey/pgpkey_test.go
@@ -723,10 +723,6 @@ func TestCreateNewEncryptionSubkey(t *testing.T) {
 		t.Fatalf("failed to generate PGP key in tests")
 	}
 	pgpKey.Subkeys = []openpgp.Subkey{} // delete existing subkey
-	err = temporaryWorkAroundSetHashPreference(pgpKey)
-	if err != nil {
-		t.Fatalf("Error setting the temporary hash preferences: %v", err)
-	}
 
 	err = pgpKey.createNewEncryptionSubkey(thirtyDaysFromNow, now)
 	if err != nil {
@@ -804,17 +800,6 @@ func TestCreateNewEncryptionSubkey(t *testing.T) {
 		}
 	})
 
-}
-
-func temporaryWorkAroundSetHashPreference(key *PgpKey) error {
-	for _, id := range key.Identities {
-		id.SelfSignature.PreferredHash = []uint8{8}
-		err := id.SelfSignature.SignUserId(id.UserId.Id, key.PrimaryKey, key.PrivateKey, nil)
-		if err != nil {
-			return fmt.Errorf("failed to make self signature: %v", err)
-		}
-	}
-	return nil
 }
 
 func TestUpdateSubkeyValidUntil(t *testing.T) {

--- a/pgpkey/pgpkey_test.go
+++ b/pgpkey/pgpkey_test.go
@@ -289,6 +289,30 @@ func TestGenerate(t *testing.T) {
 		t.Run(fmt.Sprintf("Identity[%s].SelfSignature.CreationTime", name), func(t *testing.T) {
 			assert.AssertEqualTimes(t, now, identity.SelfSignature.CreationTime)
 		})
+
+		t.Run(fmt.Sprintf("UserID[%s].SelfSignature.PreferredSymmetric matches policy", name), func(t *testing.T) {
+			assert.Equal(
+				t,
+				policy.AdvertiseCipherPreferences,
+				identity.SelfSignature.PreferredSymmetric,
+			)
+		})
+
+		t.Run(fmt.Sprintf("UserID[%s].SelfSignature.PreferredHash matches policy", name), func(t *testing.T) {
+			assert.Equal(
+				t,
+				policy.AdvertiseHashPreferences,
+				identity.SelfSignature.PreferredHash,
+			)
+		})
+
+		t.Run(fmt.Sprintf("UserID[%s].SelfSignature.PreferredCompression matches policy", name), func(t *testing.T) {
+			assert.Equal(
+				t,
+				policy.AdvertiseCompressionPreferences,
+				identity.SelfSignature.PreferredCompression,
+			)
+		})
 	}
 
 	for i, subkey := range generatedKey.Subkeys {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,13 +1,69 @@
 package policy
 
 import (
+	"github.com/fluidkeys/crypto/openpgp/packet"
 	"time"
 )
 
-const (
-	tenDays       time.Duration = time.Duration(time.Hour * 24 * 10)
-	thirtyDays    time.Duration = time.Duration(time.Hour * 24 * 30)
-	fortyFiveDays time.Duration = time.Duration(time.Hour * 24 * 45)
+var (
+	// AdvertiseCipherPreferences is added to the self signature to tell
+	// others which symmetric ciphers (in order) that we prefer to receive.
+	//
+	// When a client is choosing a cipher to use, it looks for the
+	// strongest supported by *all* recipients, and it falls back to
+	// TripleDES *even* if that's no-one's preferences.
+	//
+	// This is equivalent to this GnuPG config from Riseup's OpenPGP
+	// best practice:
+	//
+	// > personal-cipher-preferences AES256 AES192 AES CAST5
+	//
+	// https://tools.ietf.org/html/rfc4880#section-9.2
+	// https://help.riseup.net/en/security/message-security/openpgp/best-practices
+
+	AdvertiseCipherPreferences = []uint8{
+		uint8(packet.CipherAES256),
+		uint8(packet.CipherAES192),
+		uint8(packet.CipherAES128),
+		uint8(packet.CipherCAST5),
+		// TripleDES is *implicitly* supported but don't advertise
+		// it explicity in the hope that future versions ofthe spec
+		// deprecate it.
+	}
+
+	// AdvertiseCompressionPreferences is added to the self signature to tell others
+	// which compression (in order) that we prefer to use. Note that Golang
+	// doesn't support BZIP, so we don't specify that.
+	//
+	// Riseup's OpenPGP best practice settings specify:
+	//
+	// > default-preference-list [...] ZLIB BZIP2 ZIP Uncompressed
+	//
+	// https://tools.ietf.org/html/rfc4880#section-9.3
+	AdvertiseCompressionPreferences = []uint8{
+		uint8(packet.CompressionZLIB),
+		uint8(packet.CompressionZIP),
+		uint8(packet.CompressionNone),
+		// No Bzip as Go doesn't support it.
+	}
+
+	// AdvertiseHashPreferences is added to the self signature to tell
+	// others which hashes (in order) that we prefer to use.
+	//
+	// Note that clients implicity support SHA1 if no other digest is
+	// available.
+	//
+	// Riseup's OpenPGP best practice settings specify:
+	//
+	// > personal-digest-preferences SHA512 SHA384 SHA256 SHA224
+	//
+	// https://tools.ietf.org/html/rfc4880#section-9.4
+	AdvertiseHashPreferences = []uint8{
+		sha512,
+		sha384,
+		sha256,
+		sha224,
+	}
 )
 
 // NextExpiryTime returns the expiry time in UTC, according to the policy:
@@ -58,3 +114,17 @@ func beginningOfMonth(now time.Time) time.Time {
 	y, m, _ := now.Date()
 	return time.Date(y, m, 1, 0, 0, 0, 0, now.Location()).In(time.UTC)
 }
+
+const (
+	tenDays       time.Duration = time.Duration(time.Hour * 24 * 10)
+	thirtyDays    time.Duration = time.Duration(time.Hour * 24 * 30)
+	fortyFiveDays time.Duration = time.Duration(time.Hour * 24 * 45)
+)
+
+const (
+	// https://tools.ietf.org/html/rfc4880#section-9.4
+	sha256 uint8 = 8
+	sha384 uint8 = 9
+	sha512 uint8 = 10
+	sha224 uint8 = 11
+)


### PR DESCRIPTION
I've more or less followed the Riseup OpenPGP best practice document.

Note that only *new* keys get these preferences — we don't set the prefs for
previously generated keys (yet).