### PR TITLE
fix broken TestGetEncryptionSubkeyWarnings

### DIFF
--- a/exampledata/exampledata.go
+++ b/exampledata/exampledata.go
@@ -155,32 +155,3 @@ D/iQVXIhUGUcj8xSftV2Iw==
 `
 
 var ExampleFingerprint3 = fingerprint.MustParse("7C18 DE4D E478 1356 8B24  3AC8 719B D63E F03B DC20")
-
-const ExamplePublicKey4 = `
------BEGIN PGP PUBLIC KEY BLOCK-----
-Comment: gpg --export-options export-minimal --armor --export
-Comment: pub   rsa1024/0xE0245EE7E4C7A137 2018-09-24 [SC] [expires: 2020-09-23]
-Comment:       Key fingerprint = 91BA F0EC 5FEE 73AE CA10  97EC E024 5EE7 E4C7 A137
-Comment: uid                   [ultimate] test4@example.com
-Comment: sub   rsa1024/0xDB82B23C733BEC02 2018-09-24 [E] [expires: 2018-10-01]
-
-mI0EW6i7SAEEANpoQMnuOfn/JiF7cd+BFr7oG2HJv0qFEteLf9nnAi3k618oExN1
-/ygekM7WAINpyhDJIhd0VtGSeUz+h2t5wPI6Cw2S/2kCO/iuXDJnTquCDccZwR6l
-lBkl+LeRepPhxdrMgNu85gBOYXpnB5C/eLa5TP9uhmB9Q9G60n6BX2J3ABEBAAG0
-EXRlc3Q0QGV4YW1wbGUuY29tiNQEEwEIAD4WIQSRuvDsX+5zrsoQl+zgJF7n5Meh
-NwUCW6i7SAIbAwUJA8JnAAULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRDgJF7n
-5MehN6ZEA/9iXtcc2ScbYEWFVsfyTgyqXSRM95dLvOz8cdcQZJ45JctV1T/YJwKF
-FaNeGPUF+lzEWHhckl2DJaPOSmO0sW8loAOKIPvFxwYonohcP5iqn7kXOokPjCX7
-tEkXC62YEQI0e+Z4kkactodvb6LO+ghZNTip+Qowe7pvGASabA7mILiNBFuou3UB
-BACsAu4uC2or8pbFh1r7MoNMK/kDdRJCxPRL7BUoBUwoJkTb0rUieQGUwjaYjm/J
-DahxiKDe2MD5ZEnwAEIXnNuSE6QTVHDRvzaFXcEjhni4StCPXtnSRD2AocNNYUXK
-Z+h/XWMjD/AIcZg4Piy1sbEIHyHSOlIZxPoj1Sk6Ah/p5wARAQABiLwEGAEIACYW
-IQSRuvDsX+5zrsoQl+zgJF7n5MehNwUCW6i7dQIbDAUJAAk6gAAKCRDgJF7n5Meh
-Nxr7A/9QoeyT98VC/DgGRERe3vJ/jRwArHcBgdLvgeniCj1EOBcDfGbK3ODEnyIy
-gYvOyq8drfNbigSmHuijBHxtX0AYndFB4yGWHdxO8fXZ6Fvbk1SpcTOIlFqknaLI
-AZ/pcHIAAGipA1h5EsuciBwxrZ94q928uqc+jLfG6PNfgqZLeQ==
-=1vXz
------END PGP PUBLIC KEY BLOCK-----
-`
-
-var ExampleFingerprint4 = fingerprint.MustParse("91BA F0EC 5FEE 73AE CA10  97EC E024 5EE7 E4C7 A137")

--- a/exampledata/exampledata_test.go
+++ b/exampledata/exampledata_test.go
@@ -35,11 +35,6 @@ func TestArmoredKeys(t *testing.T) {
 			ExamplePrivateKey3,
 			ExampleFingerprint3,
 		},
-		{
-			`public key 4`,
-			ExamplePublicKey4,
-			ExampleFingerprint4,
-		},
 	}
 
 	for _, test := range tests {

--- a/pgpkey/pgpkey.go
+++ b/pgpkey/pgpkey.go
@@ -335,9 +335,20 @@ func (key *PgpKey) UpdateExpiryForAllUserIds(validUntil time.Time) error {
 // * has one or both of the capability flags: encrypt communications and encrypt storage
 // * has a valid, in-date signature
 // * has the latest CreationTime (e.g. most recent)
+//
+// Takes a single optional argument `now` of type time.Time. If omitted,
+// time.Now() will be used.
 
-func (key *PgpKey) EncryptionSubkey() *openpgp.Subkey {
-	return key.encryptionSubkey(time.Now())
+func (key *PgpKey) EncryptionSubkey(args ...time.Time) *openpgp.Subkey {
+	var now time.Time
+
+	if len(args) > 0 {
+		now = args[0]
+	} else {
+		now = time.Now()
+	}
+
+	return key.encryptionSubkey(now)
 }
 
 func (key *PgpKey) encryptionSubkey(now time.Time) *openpgp.Subkey {

--- a/pgpkey/pgpkey.go
+++ b/pgpkey/pgpkey.go
@@ -413,7 +413,7 @@ func (key *PgpKey) createNewEncryptionSubkey(validUntil time.Time, now time.Time
 
 // RevokeSubkey prevents the given subkey from being usable.
 func (key *PgpKey) RevokeSubkey(subkeyId uint64) error {
-	return key.updateSubkeyExpiryToNow(subkeyId, time.Now())
+	return key.UpdateSubkeyValidUntil(subkeyId, time.Now())
 }
 
 func (key *PgpKey) Subkey(subkeyId uint64) (*openpgp.Subkey, error) {
@@ -426,7 +426,7 @@ func (key *PgpKey) Subkey(subkeyId uint64) (*openpgp.Subkey, error) {
 	return nil, fmt.Errorf("no subkey with subkeyID 0x%X", subkeyId)
 }
 
-func (key *PgpKey) updateSubkeyExpiryToNow(subkeyId uint64, now time.Time) error {
+func (key *PgpKey) UpdateSubkeyValidUntil(subkeyId uint64, validUntil time.Time) error {
 	err := key.ensureGotDecryptedPrivateKey()
 	if err != nil {
 		return err
@@ -436,10 +436,10 @@ func (key *PgpKey) updateSubkeyExpiryToNow(subkeyId uint64, now time.Time) error
 		return err
 	}
 
-	keyLifetimeSeconds := uint32(now.Sub(subkey.PublicKey.CreationTime).Seconds())
+	keyLifetimeSeconds := uint32(validUntil.Sub(subkey.PublicKey.CreationTime).Seconds())
 
 	subkey.Sig.SigType = packet.SigTypeSubkeyBinding
-	subkey.Sig.CreationTime = now // essential that this sig is the most recent
+	subkey.Sig.CreationTime = validUntil // essential that this sig is the most recent
 	subkey.Sig.KeyLifetimeSecs = &keyLifetimeSeconds
 
 	err = subkey.Sig.SignKey(subkey.PublicKey, key.PrivateKey, nil)

--- a/pgpkey/pgpkey_test.go
+++ b/pgpkey/pgpkey_test.go
@@ -793,7 +793,7 @@ func temporaryWorkAroundSetHashPreference(key *PgpKey) error {
 	return nil
 }
 
-func TestUpdateSubkeyExpiryToNow(t *testing.T) {
+func TestUpdateSubkeyValidUntil(t *testing.T) {
 	now := time.Date(2018, 6, 15, 0, 0, 0, 0, time.UTC)
 	sixtyDaysAgo := now.Add(-time.Duration(24*60) * time.Hour)
 	thirtyDaysFromNow := now.Add(time.Duration(24*30) * time.Hour)
@@ -819,7 +819,7 @@ func TestUpdateSubkeyExpiryToNow(t *testing.T) {
 
 	originalSubkeySignatureCreationTime := subkey.Sig.CreationTime
 
-	err = pgpKey.updateSubkeyExpiryToNow(subkey.PublicKey.KeyId, now)
+	err = pgpKey.UpdateSubkeyValidUntil(subkey.PublicKey.KeyId, now)
 	if err != nil {
 		t.Fatalf("Error updating subkey expiry to now: " + err.Error())
 	}
@@ -987,7 +987,7 @@ func TestMethodsRequiringDecryptedPrivateKey(t *testing.T) {
 		err = pgpKey.createNewEncryptionSubkey(time.Now(), time.Now())
 		assert.ErrorIsNotNil(t, err)
 
-		err = pgpKey.updateSubkeyExpiryToNow(999, time.Now())
+		err = pgpKey.UpdateSubkeyValidUntil(999, time.Now())
 		assert.ErrorIsNotNil(t, err)
 	})
 
@@ -1006,7 +1006,7 @@ func TestMethodsRequiringDecryptedPrivateKey(t *testing.T) {
 		err = pgpKey.createNewEncryptionSubkey(time.Now(), time.Now())
 		assert.ErrorIsNotNil(t, err)
 
-		err = pgpKey.updateSubkeyExpiryToNow(999, time.Now())
+		err = pgpKey.UpdateSubkeyValidUntil(999, time.Now())
 		assert.ErrorIsNotNil(t, err)
 	})
 }

--- a/pgpkey/pgpkey_test.go
+++ b/pgpkey/pgpkey_test.go
@@ -561,7 +561,17 @@ func TestEncryptionSubkey(t *testing.T) {
 
 	})
 
-	t.Run("EncryptionSubkey selects most recent subkey", func(t *testing.T) {
+	t.Run("EncryptionSubkey() compiles with optional argument", func(t *testing.T) {
+		pgpKey.EncryptionSubkey(now)
+		// don't assert, just ensure we can compile like this
+	})
+
+	t.Run("EncryptionSubkey compiles with no argument", func(t *testing.T) {
+		pgpKey.EncryptionSubkey()
+		// don't assert, just ensure we can compile like this
+	})
+
+	t.Run("encryptionSubkey selects most recent subkey", func(t *testing.T) {
 		expectedKey := pgpKey.Subkeys[3]
 		gotKey := pgpKey.encryptionSubkey(now)
 

--- a/status/status.go
+++ b/status/status.go
@@ -20,7 +20,7 @@ func GetKeyWarnings(key pgpkey.PgpKey) []KeyWarning {
 }
 
 func getEncryptionSubkeyWarnings(key pgpkey.PgpKey, now time.Time) []KeyWarning {
-	encryptionSubkey := key.EncryptionSubkey()
+	encryptionSubkey := key.EncryptionSubkey(now)
 
 	if encryptionSubkey == nil {
 		return []KeyWarning{KeyWarning{Type: NoValidEncryptionSubkey}}


### PR DESCRIPTION
Rather than using the ExamplePublicKey4, whcih relied on *real-world* now
rather than a test now, use ExamplePrivateKey2 and tweak its subkey and
primary key expiration times in the test.

* rename & export `PgpKey.updateSubPgpKeyExpiryToNow` as `PgpKey.UpdateSubPgpKeyValidUntil`
* pgpkey:EncryptionSubkey: take optional `now` arg
* delete ExamplePublicKey4

  - it has a short expiry date, so it has now expired (the test was written
to depend on *real* now rather than passed-in `now`)
  - the private key is not committed, so I'm unable to edit the key :(