### PR TITLE
add openpgpdefs subpackage

### DIFF
--- a/openpgpdefs/compression/compression.go
+++ b/openpgpdefs/compression/compression.go
@@ -1,0 +1,11 @@
+package compression
+
+type CompressionAlgorithm = uint8
+
+const (
+	// https://tools.ietf.org/html/rfc4880#section-9.3
+	Uncompressed CompressionAlgorithm = 0
+	ZIP                               = 1
+	ZLIB                              = 2
+	BZIP2                             = 3
+)

--- a/openpgpdefs/hash/hash.go
+++ b/openpgpdefs/hash/hash.go
@@ -1,0 +1,50 @@
+package hash
+
+import (
+	"fmt"
+)
+
+type HashAlgorithm = uint8
+
+const (
+	// https://tools.ietf.org/html/rfc4880#section-9.4
+	Md5       HashAlgorithm = 1
+	Sha1                    = 2
+	Ripemd160               = 3
+	Sha256                  = 8
+	Sha384                  = 9
+	Sha512                  = 10
+	Sha224                  = 11
+)
+
+func Name(hashByte uint8) string {
+	switch hashByte {
+	case 1:
+		return "MD5"
+	case 2:
+		return "SHA1"
+	case 3:
+		return "RIPEMD160"
+	case 4, 5, 6, 7:
+		return fmt.Sprintf("Reserved (%d)", hashByte)
+
+	case 8:
+		return "SHA256"
+
+	case 9:
+		return "SHA384"
+
+	case 10:
+		return "SHA512"
+
+	case 11:
+		return "SHA224"
+
+	case 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110:
+		return fmt.Sprintf("Private/experimental (%d)", hashByte)
+
+	default:
+		return fmt.Sprintf("Unknown (%d)", hashByte)
+	}
+
+}

--- a/openpgpdefs/symmetric/symmetric.go
+++ b/openpgpdefs/symmetric/symmetric.go
@@ -1,0 +1,67 @@
+package symmetric
+
+import (
+	"fmt"
+)
+
+type SymmetricAlgorithm = uint8
+
+const (
+	// https://tools.ietf.org/html/rfc4880#section-9.2
+	IDEA       SymmetricAlgorithm = 1 // not defined in openpgp.packet CipherFunction
+	TripleDES                     = 2
+	CAST5                         = 3
+	Blowfish                      = 4 // not defined in openpgp.packet CipherFunction
+	AES128                        = 7
+	AES192                        = 8
+	AES256                        = 9
+	Twofish256                    = 10 // not defined in openpgp.packet CipherFunction
+
+	// https://tools.ietf.org/html/rfc5581#section-3
+	Camellia128 = 11 // not defined in openpgp.packet CipherFunction
+	Camellia192 = 12
+	Camellia256 = 13
+)
+
+func Name(symmetricAlgorithm SymmetricAlgorithm) string {
+	switch symmetricAlgorithm {
+	case 1:
+		return "IDEA"
+	case 2:
+		return "TripleDES"
+	case 3:
+		return "CAST5"
+	case 4:
+		return "Blowfish"
+	case 5, 6:
+		return fmt.Sprintf("Reserved (%d)", symmetricAlgorithm)
+
+	case 7:
+		return "AES128"
+
+	case 8:
+		return "AES192"
+
+	case 9:
+		return "AES256"
+
+	case 10:
+		return "Twofish"
+
+	case 11:
+		return "Camellia128"
+
+	case 12:
+		return "Camellia192"
+
+	case 13:
+		return "Camellia256"
+
+	case 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110:
+		return fmt.Sprintf("Private/experimental (%d)", symmetricAlgorithm)
+
+	default:
+		return fmt.Sprintf("Unknown (%d)", symmetricAlgorithm)
+	}
+
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,7 +1,9 @@
 package policy
 
 import (
-	"github.com/fluidkeys/crypto/openpgp/packet"
+	"github.com/fluidkeys/fluidkeys/openpgpdefs/compression"
+	"github.com/fluidkeys/fluidkeys/openpgpdefs/hash"
+	"github.com/fluidkeys/fluidkeys/openpgpdefs/symmetric"
 	"time"
 )
 
@@ -22,10 +24,10 @@ var (
 	// https://help.riseup.net/en/security/message-security/openpgp/best-practices
 
 	AdvertiseCipherPreferences = []uint8{
-		uint8(packet.CipherAES256),
-		uint8(packet.CipherAES192),
-		uint8(packet.CipherAES128),
-		uint8(packet.CipherCAST5),
+		symmetric.AES256,
+		symmetric.AES192,
+		symmetric.AES128,
+		symmetric.CAST5,
 		// TripleDES is *implicitly* supported but don't advertise
 		// it explicity in the hope that future versions ofthe spec
 		// deprecate it.
@@ -41,9 +43,9 @@ var (
 	//
 	// https://tools.ietf.org/html/rfc4880#section-9.3
 	AdvertiseCompressionPreferences = []uint8{
-		uint8(packet.CompressionZLIB),
-		uint8(packet.CompressionZIP),
-		uint8(packet.CompressionNone),
+		compression.ZLIB,
+		compression.ZIP,
+		compression.Uncompressed,
 		// No Bzip as Go doesn't support it.
 	}
 
@@ -59,10 +61,10 @@ var (
 	//
 	// https://tools.ietf.org/html/rfc4880#section-9.4
 	AdvertiseHashPreferences = []uint8{
-		sha512,
-		sha384,
-		sha256,
-		sha224,
+		hash.Sha512,
+		hash.Sha384,
+		hash.Sha256,
+		hash.Sha224,
 	}
 )
 
@@ -119,12 +121,4 @@ const (
 	tenDays       time.Duration = time.Duration(time.Hour * 24 * 10)
 	thirtyDays    time.Duration = time.Duration(time.Hour * 24 * 30)
 	fortyFiveDays time.Duration = time.Duration(time.Hour * 24 * 45)
-)
-
-const (
-	// https://tools.ietf.org/html/rfc4880#section-9.4
-	sha256 uint8 = 8
-	sha384 uint8 = 9
-	sha512 uint8 = 10
-	sha224 uint8 = 11
 )


### PR DESCRIPTION
This defines constants from RFC 4880 and RFC 5881 for symmetric key
algorithms, hash algorithms and compression algorithms.

The reason for defining these is that openpgp.packet is incomplete: for
example it doesn't define any bytes that it can't support (like BZIP2).

That matters because we want to be able to *test* for BZIP2 in imported
keys to warn that it's not usable.