### PR TITLE
Format `key rotate` in line with the new designs

### DIFF
--- a/colour/colour.go
+++ b/colour/colour.go
@@ -85,6 +85,10 @@ func CommandLineCode(message string) string {
 	return bright + blue(message)
 }
 
+func Disabled(message string) string {
+	return grey(message)
+}
+
 func underline(message string) string {
 	return underscore + message + reset
 }

--- a/fluidkeys/keyrotate.go
+++ b/fluidkeys/keyrotate.go
@@ -223,9 +223,9 @@ func printCheckboxFailure(actionText string, err error) {
 	fmt.Printf("\r        %s\n", colour.Error(fmt.Sprintf("%s", err)))
 }
 
-// printKeyWarningsAndActions outputs a header for each key as follows:
+// makeKeyWarningsAndActions outputs a header for each key as follows:
 //
-// Two issues for foo@example.com:
+// 2 issues for foo@example.com:
 //
 // ▸   Encryption subkey overdue for rotation, expires in 5 days
 // ▸   Primary key set to expire too far in the future

--- a/fluidkeys/keyrotate.go
+++ b/fluidkeys/keyrotate.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/fluidkeys/fluidkeys/colour"
 	"github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/humanize"
-	"github.com/fluidkeys/fluidkeys/keytableprinter"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/fluidkeys/fluidkeys/status"
 	"time"
@@ -16,8 +16,6 @@ func keyRotate(dryRun bool) exitCode {
 	if err != nil {
 		panic(err)
 	}
-
-	keytableprinter.Print(keys)
 
 	if dryRun {
 		return runKeyRotateDryRun(keys)

--- a/fluidkeys/keyrotate.go
+++ b/fluidkeys/keyrotate.go
@@ -62,13 +62,22 @@ func runKeyRotate(keys []pgpkey.PgpKey) exitCode {
 		actions := status.MakeActionsFromWarnings(warnings, time.Now())
 		fmt.Printf(makeKeyWarningsAndActions(key, warnings, actions))
 
-		if len(actions) > 0 {
+		numberOfActions := len(actions)
+		if numberOfActions > 0 {
 			anyKeysHadActions = true
 		} else {
 			continue // nothing to do. next key.
 		}
 
-		if promptYesOrNo("     Run these actions? [Y/n] ", true) == false {
+		var prompt string
+		switch numberOfActions {
+		case 1:
+			prompt = "     Run this action? [Y/n] "
+		default:
+			prompt = fmt.Sprintf("     Run these %d actions? [Y/n] ", numberOfActions)
+		}
+
+		if promptYesOrNo(prompt, true) == false {
 			fmt.Printf(colour.Disabled(" ▸   OK, skipped.\n"))
 			continue // next key
 		}

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -213,8 +213,8 @@ func loadPgpKeys() ([]pgpkey.PgpKey, error) {
 func keyCreate() exitCode {
 
 	if !gpg.IsWorking() {
-		fmt.Printf(colour.Warning("\n" + GPGMissing + "\n"))
-		fmt.Printf(ContinueWithoutGPG)
+		fmt.Print(colour.Warning("\n" + GPGMissing + "\n"))
+		fmt.Print(ContinueWithoutGPG + "\n")
 		promptForInput("Press enter to continue. ")
 	}
 	email := promptForEmail()
@@ -232,8 +232,7 @@ func keyCreate() exitCode {
 		}
 	}
 
-	fmt.Println("Generating key for", email)
-	fmt.Println()
+	fmt.Print("Generating key for " + email + "\n\n")
 
 	generateJob := <-channel
 
@@ -394,7 +393,7 @@ func promptYesOrNo(message string, defaultResult bool) bool {
 }
 
 func promptForInputWithPipes(prompt string, reader *bufio.Reader) string {
-	fmt.Printf("\n" + prompt)
+	fmt.Print(prompt)
 	response, err := reader.ReadString('\n')
 	if err != nil {
 		panic(err)
@@ -408,7 +407,7 @@ func promptForInput(prompt string) string {
 }
 
 func promptForEmail() string {
-	fmt.Print(PromptEmail)
+	fmt.Print(PromptEmail + "\n")
 	return promptForInput("[email] : ")
 }
 
@@ -420,8 +419,8 @@ func generatePassword(numberOfWords int, separator string) DicewarePassword {
 }
 
 func displayPassword(message string, password DicewarePassword) {
-	fmt.Printf(message)
-	fmt.Printf("\n  %v\n", colour.Info(password.AsString()))
+	fmt.Print(message + "\n")
+	fmt.Print("  " + colour.Info(password.AsString()) + "\n\n")
 
 	promptForInput("Press enter when you've written it down. ")
 }
@@ -433,7 +432,7 @@ func userConfirmedRandomWord(password DicewarePassword) bool {
 	correctWord := password.words[randomIndex]
 	wordOrdinal := humanize.Ordinal(randomIndex + 1)
 
-	fmt.Printf("Enter the %s word from your password\n", wordOrdinal)
+	fmt.Printf("Enter the %s word from your password\n\n", wordOrdinal)
 	givenWord := promptForInput("[" + wordOrdinal + " word] : ")
 	return givenWord == correctWord
 }

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -298,7 +298,7 @@ func displayName(key *pgpkey.PgpKey) string {
 	if err != nil {
 		displayName = fmt.Sprintf("%s", key.Fingerprint())
 	}
-	return displayName
+	return colour.Info(displayName)
 }
 
 func getFluidkeysDirectory() (string, error) {


### PR DESCRIPTION
For each key we now print a list of the warnings followed by the actions
that Fluidkeys will carry out, e.g:

```
6 warnings for test@example.com

 ▸   Primary key overdue for rotation, expires in 11 days
 ▸   Encryption subkey overdue for rotation, expires in 11 days
 ▸   Primary key has weak preferred symmetric algorithms (AES256, AES192, AES128, TripleDES)
 ▸   Primary key has weak preferred hash algorithms (SHA512, SHA384, SHA256, SHA224, SHA1)
 ▸   Primary key missing uncompressed preference
 ▸   Primary key has unsupported preferred compression algorithm (BZIP2)

     [ ] Extend the primary key expiry to 1 Dec 18
     [ ] Set preferred encryption algorithms to AES256, AES192, AES128, CAST5
     [ ] Set preferred hash algorithms to SHA512, SHA384, SHA256, SHA224
     [ ] Set preferred compression algorithms to ZLIB, ZIP, Uncompressed
     [ ] Create a new encryption subkey valid until 1 Dec 18
     [ ] Expire the encryption subkey now (0x1701731E97E4DE23)
```

This also involves nudging the checkbox actions one rune to the right to
line up with the bulleted list of warnings.

In this request I've been a bit naughty. I also started changing how we handle
our line spacing. 👹

We've agreed now that all spacing is handled at the end of a 'section' (by
section, I mean list of checkboxes, paragraph of text, etc).

This has ramifications all over the code. Sorry!