### PR TITLE
Fix the fact fluidkeysDirectory was never set

### DIFF
--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -65,7 +65,8 @@ type generatePgpKeyResult struct {
 type exitCode = int
 
 func init() {
-	fluidkeysDirectory, err := getFluidkeysDirectory()
+	var err error
+	fluidkeysDirectory, err = getFluidkeysDirectory()
 	if err != nil {
 		fmt.Printf("Failed to get fluidkeys directory: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Factoring out the global variable in 58d15f03 broke things.