### PR TITLE
Start storing backups in date-stamped subdirectories

### DIFF
--- a/backupzip/backupzip.go
+++ b/backupzip/backupzip.go
@@ -41,7 +41,7 @@ func OutputZipBackupFile(
 		panic(fmt.Sprintf("Failed to get slug for key to work out backup location"))
 	}
 
-	filename = getZipFilename(fluidkeysDir, keySlug)
+	filename = getZipFilename(fluidkeysDir, keySlug, time.Now())
 
 	backupZipFile, err := os.Create(filename)
 	if err != nil {
@@ -105,8 +105,9 @@ func makeFileWriter(zipWriter *zip.Writer, filename string) (io.Writer, error) {
 	return writer, nil
 }
 
-func getZipFilename(fluidkeysDir string, slug string) string {
-	backupDirectory := filepath.Join(fluidkeysDir, "backups")
+func getZipFilename(fluidkeysDir string, slug string, now time.Time) string {
+	dateSubdirectory := now.Format("2006-01-02")
+	backupDirectory := filepath.Join(fluidkeysDir, "backups", dateSubdirectory)
 	os.MkdirAll(backupDirectory, 0700)
 	return filepath.Join(backupDirectory, slug+".zip")
 }

--- a/backupzip/backupzip_test.go
+++ b/backupzip/backupzip_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/fluidkeys/fluidkeys/assert"
 )
@@ -55,8 +56,9 @@ func TestMakeBackupFile(t *testing.T) {
 	})
 
 	t.Run("getZipFilename returns correct location", func(t *testing.T) {
-		assertEqual(t, "/tmp/fluidkeys/backups/2018-01-15-test-example-com-FAKEFINGERPRINT.zip", getZipFilename("/tmp/fluidkeys", exampleSlug))
-		assertEqual(t, "/tmp/.foo/backups/2018-01-15-test-example-com-FAKEFINGERPRINT.zip", getZipFilename("/tmp/.foo", exampleSlug))
+		now := time.Date(2018, 6, 15, 16, 0, 0, 0, time.UTC)
+		assertEqual(t, "/tmp/fluidkeys/backups/2018-06-15/2018-01-15-test-example-com-FAKEFINGERPRINT.zip", getZipFilename("/tmp/fluidkeys", exampleSlug, now))
+		assertEqual(t, "/tmp/.foo/backups/2018-06-15/2018-01-15-test-example-com-FAKEFINGERPRINT.zip", getZipFilename("/tmp/.foo", exampleSlug, now))
 	})
 
 }

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -247,7 +247,7 @@ func keyCreate() exitCode {
 		fmt.Printf("Failed to create backup ZIP file: %s", err)
 	}
 	directory, _ := filepath.Split(filename)
-	fmt.Printf("Full key backup saved in %s\n" directory)
+	fmt.Printf("Full key backup saved in %s\n", directory)
 
 	pushPrivateKeyBackToGpg(generateJob.pgpKey, password.AsString(), &gpg)
 	fmt.Println("The new key has been imported into GnuPG, inspect it with:")

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -242,11 +242,11 @@ func keyCreate() exitCode {
 		panic(fmt.Sprint("Failed to generate key: ", generateJob.err))
 	}
 
-	_, err := backupzip.OutputZipBackupFile(fluidkeysDirectory, generateJob.pgpKey, password.AsString())
+	filename, err := backupzip.OutputZipBackupFile(fluidkeysDirectory, generateJob.pgpKey, password.AsString())
 	if err != nil {
 		fmt.Printf("Failed to create backup ZIP file: %s", err)
 	}
-	fmt.Printf("Full key backup saved to %s\n", fluidkeysDirectory)
+	fmt.Printf("Full key backup saved to %s\n", filename)
 
 	pushPrivateKeyBackToGpg(generateJob.pgpKey, password.AsString(), &gpg)
 	fmt.Println("The new key has been imported into GnuPG, inspect it with:")

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -246,7 +246,8 @@ func keyCreate() exitCode {
 	if err != nil {
 		fmt.Printf("Failed to create backup ZIP file: %s", err)
 	}
-	fmt.Printf("Full key backup saved to %s\n", filename)
+	directory, _ := filepath.Split(filename)
+	fmt.Printf("Full key backup saved in %s\n" directory)
 
 	pushPrivateKeyBackToGpg(generateJob.pgpKey, password.AsString(), &gpg)
 	fmt.Println("The new key has been imported into GnuPG, inspect it with:")


### PR DESCRIPTION
This subdirectory is created from the date at which the backup is created (as opposed to the key's slug, which is the date at which the key was created).

We also now print the full path of the backup directory, rather than just the fluidkeys directory.