### PR TITLE
fix UpdateSubkeyValidUntil — pass in `now` arg

### DIFF
--- a/status/status_test.go
+++ b/status/status_test.go
@@ -117,7 +117,7 @@ func TestGetEncryptionSubkeyWarnings(t *testing.T) {
 		verySoon := now.Add(time.Duration(6) * time.Hour)
 		veryFarAway := now.Add(time.Duration(100*24) * time.Hour)
 
-		err = pgpKey.UpdateSubkeyValidUntil(pgpKey.EncryptionSubkey(now).PublicKey.KeyId, verySoon)
+		err = pgpKey.UpdateSubkeyValidUntil(pgpKey.EncryptionSubkey(now).PublicKey.KeyId, verySoon, now)
 		if err != nil {
 			t.Fatalf("failed to update expiry on test subkey")
 		}


### PR DESCRIPTION
(rebase after merging #135)

previously `validUntil` was being used as the signature `CreationTime`.

That's a trap: if you updated the validity to the years in the future, the
future-dated signature would override any new signatures trying to shorten
the subkey expiry (because the future-dated signature would always be the
"newest")