### PR TITLE
add Config.ShouldRotateAutomatically & tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,11 +43,25 @@ type Config struct {
 	parsedMetadata toml.MetaData
 }
 
+// ShouldStorePasswordForKey returns whether the given key's password should
+// be stored in the system keyring when successfully entered (avoiding future
+// password prompts).
+// The default is false.
 func (c *Config) ShouldStorePasswordForKey(fingerprint fingerprint.Fingerprint) bool {
 	if keyConfig, gotConfig := c.getConfig(fingerprint); gotConfig {
 		return keyConfig.StorePassword
 	} else {
 		return defaultStorePassword
+	}
+}
+
+// ShouldRotateAutomaticallyForKey returns whether the given key should be
+// rotated in the background. The default is false.
+func (c *Config) ShouldRotateAutomaticallyForKey(fingerprint fingerprint.Fingerprint) bool {
+	if keyConfig, gotConfig := c.getConfig(fingerprint); gotConfig {
+		return keyConfig.RotateAutomatically
+	} else {
+		return defaultRotateAutomatically
 	}
 }
 
@@ -102,10 +116,12 @@ type tomlConfig struct {
 }
 
 type key struct {
-	StorePassword bool `toml:"store_password"`
+	StorePassword       bool `toml:"store_password"`
+	RotateAutomatically bool `toml:"rotate_automatically"`
 }
 
 const defaultStorePassword bool = false
+const defaultRotateAutomatically bool = false
 const defaultConfigFile string = `# Fluidkeys default configuration file.
 
 [pgpkeys]
@@ -114,5 +130,6 @@ const defaultConfigFile string = `# Fluidkeys default configuration file.
 # add the following configuration lines using the key's fingerprint:
 #
 #     [pgpkeys.AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111]
-#     store_password = false
+#     store_password = true
+#     rotate_automatically = true
 `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,50 +93,101 @@ func TestLoad(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
-	str := strings.NewReader(exampleTomlDocument)
-	config, err := parse(str)
-	assert.ErrorIsNil(t, err)
 
-	t.Run("parsedMetadata.IsDefined('keys') should be true", func(t *testing.T) {
-		assert.Equal(t, true, config.parsedMetadata.IsDefined("pgpkeys"))
+	t.Run("with valid example config.toml", func(t *testing.T) {
+		str := strings.NewReader(exampleTomlDocument)
+		config, err := parse(str)
+		assert.ErrorIsNil(t, err)
+		t.Run("parsedMetadata.IsDefined('keys') should be true", func(t *testing.T) {
+			assert.Equal(t, true, config.parsedMetadata.IsDefined("pgpkeys"))
+		})
+
+		t.Run("parsedMetadata.IsDefined('keys', '<fingerprint>') should be true", func(t *testing.T) {
+			assert.Equal(t, true, config.parsedMetadata.IsDefined(
+				"pgpkeys", "AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111",
+			))
+		})
+
+		t.Run("metadata.Undecoded() should be empty", func(t *testing.T) {
+			assert.Equal(t, 0, len(config.parsedMetadata.Undecoded()))
+		})
+
+		t.Run("parsedConfig has 2 PgpKeys", func(t *testing.T) {
+			assert.Equal(t, 2, len(config.parsedConfig.PgpKeys))
+		})
+
+		t.Run("first PgpKey should have store_password=true", func(t *testing.T) {
+			firstKey, inMap := config.parsedConfig.PgpKeys["AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111"]
+
+			if !inMap {
+				t.Fatalf("key wasn't in the map")
+			}
+			assert.Equal(t, true, firstKey.StorePassword)
+		})
 	})
 
-	t.Run("parsedMetadata.IsDefined('keys', '<fingerprint>') should be true", func(t *testing.T) {
-		assert.Equal(t, true, config.parsedMetadata.IsDefined(
-			"pgpkeys", "AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111",
-		))
+	t.Run("return an error if an invalid fingerprint is encountered", func(t *testing.T) {
+		_, err := parse(strings.NewReader(`
+		[pgpkeys]
+		[pgpkeys.invalid-fingerprint]
+		store_password = false
+		`))
+		assert.ErrorIsNotNil(t, err)
 	})
 
-	t.Run("metadata.Undecoded() should be empty", func(t *testing.T) {
-		assert.Equal(t, 0, len(config.parsedMetadata.Undecoded()))
+	t.Run("return an error if an unrecognised config variable is encountered", func(t *testing.T) {
+		_, err := parse(strings.NewReader(`
+		[pgpkeys]
+		[pgpkeys.AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111]
+		unrecognised_option = false
+		`))
+		assert.ErrorIsNotNil(t, err)
+		assert.Equal(t, "encountered unrecognised config keys: [pgpkeys.AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111.unrecognised_option]", err.Error())
 	})
+}
 
-	t.Run("parsedConfig has 2 PgpKeys", func(t *testing.T) {
-		assert.Equal(t, 2, len(config.parsedConfig.PgpKeys))
+func TestGetConfig(t *testing.T) {
+	fingerprint := fingerprint.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
+
+	t.Run("getConfig recognises 0xAAAA... fingerprint format", func(t *testing.T) {
+		config, err := parse(strings.NewReader(`
+		[pgpkeys]
+		[pgpkeys.0xAAAA1111AAAA1111AAAA1111AAAA1111AAAA1111]
+		store_password = false
+		`))
+		assert.ErrorIsNil(t, err)
+
+		_, gotConfig := config.getConfig(fingerprint)
+
+		assert.ErrorIsNil(t, err)
+		assert.Equal(t, true, gotConfig)
 	})
+	t.Run("getConfig recognises 'AAAA 1111...' fingerprint format", func(t *testing.T) {
+		config, err := parse(strings.NewReader(`
+		[pgpkeys]
+		[pgpkeys."AAAA 1111 AAAA 1111 AAAA 1111 AAAA 1111 AAAA 1111"]
+		store_password = false
+		`))
+		assert.ErrorIsNil(t, err)
 
-	t.Run("first PgpKey should have store_password=true", func(t *testing.T) {
-		firstKey, inMap := config.parsedConfig.PgpKeys["AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111"]
+		_, gotConfig := config.getConfig(fingerprint)
 
-		if !inMap {
-			t.Fatalf("key wasn't in the map")
-		}
-		assert.Equal(t, true, firstKey.StorePassword)
+		assert.ErrorIsNil(t, err)
+		assert.Equal(t, true, gotConfig)
 	})
-
 }
 
 func TestShouldStorePasswordInKeyring(t *testing.T) {
 	fingerprint := fingerprint.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
 
-	t.Run("default to true for missing whole [keys] table", func(t *testing.T) {
+	t.Run("default to false for missing whole [keys] table", func(t *testing.T) {
 		config, err := parse(strings.NewReader(""))
 		assert.ErrorIsNil(t, err)
 
 		got := config.ShouldStorePasswordForKey(fingerprint)
-		assert.Equal(t, true, got)
+		assert.Equal(t, false, got)
 	})
-	t.Run("default to true for missing key fingerprint", func(t *testing.T) {
+	t.Run("default to false for missing key fingerprint", func(t *testing.T) {
 		config, err := parse(strings.NewReader(`
 		[pgpkeys]
 		[pgpkeys.0000000000000000000000000000000000000000]
@@ -145,10 +196,10 @@ func TestShouldStorePasswordInKeyring(t *testing.T) {
 		assert.ErrorIsNil(t, err)
 
 		got := config.ShouldStorePasswordForKey(fingerprint)
-		assert.Equal(t, true, got)
+		assert.Equal(t, false, got)
 	})
 
-	t.Run("default to true for missing store_password key", func(t *testing.T) {
+	t.Run("default to false for missing store_password key", func(t *testing.T) {
 		config, err := parse(strings.NewReader(`
 		[pgpkeys]
 		[pgpkeys.AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111]
@@ -156,7 +207,7 @@ func TestShouldStorePasswordInKeyring(t *testing.T) {
 		assert.ErrorIsNil(t, err)
 
 		got := config.ShouldStorePasswordForKey(fingerprint)
-		assert.Equal(t, true, got)
+		assert.Equal(t, false, got)
 	})
 
 	t.Run("return false if store_password key is false", func(t *testing.T) {


### PR DESCRIPTION
As part of this, improve Config class

* allow different Fingerprint formats
* panic if an invalid fingerprint is found
* panic if an unrecognised config variable is encountered
* change store_password default to false