### PR TITLE
Timestamp all file backups

### DIFF
--- a/archiver/archiver.go
+++ b/archiver/archiver.go
@@ -6,7 +6,22 @@ import (
 	"time"
 )
 
-func DateStampedDirectory(fluidkeysDir string, now time.Time) string {
+// MakeFilePath takes a filename, extension, directory and time and constructs
+// a filepath string formated like:
+//   directory/2016-08-23/filename-180500.ext
+func MakeFilePath(filename string, extension string, directory string, now time.Time) string {
+	return filepath.Join(
+		dateStampedDirectory(directory, now),
+		appendTimeStampToFilename(filename, extension, now),
+	)
+}
+
+func appendTimeStampToFilename(filename string, extension string, now time.Time) string {
+	timestamp := now.Format("150405")
+	return filename + "-" + timestamp + "." + extension
+}
+
+func dateStampedDirectory(fluidkeysDir string, now time.Time) string {
 	dateSubdirectory := now.Format("2006-01-02")
 	backupDirectory := filepath.Join(fluidkeysDir, "backups", dateSubdirectory)
 	os.MkdirAll(backupDirectory, 0700)

--- a/archiver/archiver.go
+++ b/archiver/archiver.go
@@ -8,7 +8,7 @@ import (
 
 // MakeFilePath takes a filename, extension, directory and time and constructs
 // a filepath string formated like:
-//   directory/2016-08-23/filename-180500.ext
+//   directory/2016-08-23/filename-2016-08-23T18-05-00.ext
 func MakeFilePath(filename string, extension string, directory string, now time.Time) string {
 	return filepath.Join(
 		dateStampedDirectory(directory, now),
@@ -17,7 +17,7 @@ func MakeFilePath(filename string, extension string, directory string, now time.
 }
 
 func appendTimeStampToFilename(filename string, extension string, now time.Time) string {
-	timestamp := now.Format("150405")
+	timestamp := now.Format("2006-01-02T15-04-05")
 	return filename + "-" + timestamp + "." + extension
 }
 

--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -17,7 +17,7 @@ func TestMakeFilePath(t *testing.T) {
 	filename := "foo"
 	extension := "txt"
 
-	expect := directory + "/backups/2018-06-15/foo-153201.txt"
+	expect := directory + "/backups/2018-06-15/foo-2018-06-15T15-32-01.txt"
 	got := MakeFilePath(filename, extension, directory, now)
 
 	assert.Equal(t, expect, got)

--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -1,0 +1,24 @@
+package archiver
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+)
+
+func TestMakeFilePath(t *testing.T) {
+	now := time.Date(2018, 6, 15, 15, 32, 1, 0, time.UTC)
+	directory, err := ioutil.TempDir("", "fluidkey.backup_test_directory.")
+	if err != nil {
+		t.Fatalf("error creating temporary directory")
+	}
+	filename := "foo"
+	extension := "txt"
+
+	expect := directory + "/backups/2018-06-15/foo-153201.txt"
+	got := MakeFilePath(filename, extension, directory, now)
+
+	assert.Equal(t, expect, got)
+}

--- a/backupzip/backupzip.go
+++ b/backupzip/backupzip.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/fluidkeys/fluidkeys/archiver"
@@ -42,7 +41,7 @@ func OutputZipBackupFile(
 		panic(fmt.Sprintf("Failed to get slug for key to work out backup location"))
 	}
 
-	filename = getZipFilename(fluidkeysDir, keySlug, time.Now())
+	filename = archiver.MakeFilePath(keySlug, "zip", fluidkeysDir, time.Now())
 
 	backupZipFile, err := os.Create(filename)
 	if err != nil {
@@ -104,9 +103,4 @@ func makeFileWriter(zipWriter *zip.Writer, filename string) (io.Writer, error) {
 		return nil, fmt.Errorf("zipWriter.CreateHeader(..) failed: %v", err)
 	}
 	return writer, nil
-}
-
-func getZipFilename(fluidkeysDir string, slug string, now time.Time) string {
-	directory := archiver.DateStampedDirectory(fluidkeysDir, now)
-	return filepath.Join(directory, slug+".zip")
 }

--- a/backupzip/backupzip_test.go
+++ b/backupzip/backupzip_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/fluidkeys/fluidkeys/assert"
 )
@@ -53,12 +52,6 @@ func TestMakeBackupFile(t *testing.T) {
 		assertEqual(t, string(fileContents["2018-01-15-test-example-com-FAKEFINGERPRINT.public.txt"]), examplePublicKey)
 		assertEqual(t, string(fileContents["2018-01-15-test-example-com-FAKEFINGERPRINT.private.encrypted.txt"]), examplePrivateKey)
 		assertEqual(t, string(fileContents["2018-01-15-test-example-com-FAKEFINGERPRINT.revoke.txt"]), exampleRevocationCert)
-	})
-
-	t.Run("getZipFilename returns correct location", func(t *testing.T) {
-		now := time.Date(2018, 6, 15, 16, 0, 0, 0, time.UTC)
-		assertEqual(t, "/tmp/fluidkeys/backups/2018-06-15/2018-01-15-test-example-com-FAKEFINGERPRINT.zip", getZipFilename("/tmp/fluidkeys", exampleSlug, now))
-		assertEqual(t, "/tmp/.foo/backups/2018-06-15/2018-01-15-test-example-com-FAKEFINGERPRINT.zip", getZipFilename("/tmp/.foo", exampleSlug, now))
 	})
 
 }

--- a/fluidkeys/keyrotate.go
+++ b/fluidkeys/keyrotate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -302,7 +301,7 @@ func promptAndBackupGnupg(prompter promptYesNoInterface) {
 
 	if prompter.promptYesNo(promptBackupGpg, "y", nil) == true {
 		printCheckboxPending(action)
-		filename, err := makeGnupgBackup()
+		filename, err := makeGnupgBackup(time.Now())
 		if err != nil {
 			printCheckboxFailure(action, err)
 			fmt.Printf("\n")
@@ -315,10 +314,9 @@ func promptAndBackupGnupg(prompter promptYesNoInterface) {
 	}
 }
 
-func makeGnupgBackup() (string, error) {
-	directory := archiver.DateStampedDirectory(fluidkeysDirectory, time.Now())
-	filepath := filepath.Join(directory, "gpghome.tgz")
-	filename, err := gpg.BackupHomeDir(filepath, time.Now())
+func makeGnupgBackup(now time.Time) (string, error) {
+	filepath := archiver.MakeFilePath("gpghome", "tgz", fluidkeysDirectory, now)
+	filename, err := gpg.BackupHomeDir(filepath, now)
 	return filename, err
 }
 


### PR DESCRIPTION
Rather than just put backup zips in subdirectories of dates, we now put the
time stamp on the end of each file.

i.e: `/backups/2018-10-19/gpghome-110713.tgz`