### PR TITLE
add ISSUE_TEMPLATE.md, signposting our Trello

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+Before you add an issue, it's worth looking [at public Trello board](https://trello.com/b/dB9j4JaG/fluidkeys?menu=filter&filter=label:BUG) to see if we're already working on it.
+
+Then, go ahead and raise the issue on Github.
+
+----
+
+Thanks for trying out Fluidkeys and taking the time to raise an issue :)
+
+Please include:
+
+- [ ] Fluidkeys version number or commit hash (see `fk --help` or `git log`):
+- [ ] Your operating system, e.g. `macOS Mojave`, `Ubuntu 18.04`
+- [ ] Your GnuPG version: `gpg2 --version`


### PR DESCRIPTION
I've made this as an issue template so that users would-be bug reporters
see the link to Trello inline, right after they start to create a new
issue.

I prefer this to asking reporters to go and read 2 separate documents
(contributing guide), since we don't have anything more to say yet.