### PR TITLE
log most output to `debug.log`

### DIFF
--- a/fluidkeys/init.go
+++ b/fluidkeys/init.go
@@ -15,11 +15,11 @@ import (
 
 func init() {
 	initFluidkeysDirectory()
+	initOutput()
 	initConfig()
 	initKeyring()
 	initDatabase()
 	initGpgWrapper()
-	initOutput()
 }
 
 func initFluidkeysDirectory() {
@@ -60,7 +60,9 @@ func initGpgWrapper() {
 }
 
 func initOutput() {
-	out.SetOutputToTerminal()
+	if err := out.Load(fluidkeysDirectory); err != nil {
+		panic(err)
+	}
 }
 
 func getFluidkeysDirectory() (string, error) {

--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -116,7 +116,7 @@ func generatePassword(numberOfWords int, separator string) DicewarePassword {
 }
 
 func displayPassword(password DicewarePassword) {
-	out.Print("  " + colour.Info(password.AsString()) + "\n\n")
+	out.Print(out.NoLogCharacter + "   " + colour.Info(password.AsString()) + "\n\n")
 	out.Print("If you use a password manager, save it there now.\n\n")
 	out.Print(colour.Warning("Store this safely, otherwise you won’t be able to use your key\n\n"))
 

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -53,6 +54,7 @@ Options:
 		Config.GetFilename(),
 	)
 
+	log.Print("$ " + strings.Join(os.Args, " "))
 	args, _ := docopt.ParseDoc(usage)
 
 	ensureCrontabStateMatchesConfig()

--- a/out/out.go
+++ b/out/out.go
@@ -1,11 +1,35 @@
 package out
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
 
 var outputter outputterInterface
 
 func init() {
+	// this is necessary for tests to use out.Print (they don't init
+	// through the main function)
 	SetOutputToTerminal()
+}
+
+func Load(logDirectory string) error {
+	if logDirectory == "" {
+		return fmt.Errorf("missing log directory")
+	}
+	SetOutputToTerminal()
+
+	logFilename := filepath.Join(logDirectory, "debug.log")
+
+	if f, err := os.OpenFile(logFilename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err != nil {
+		return fmt.Errorf("failed to open '%s' for writing: %v", logFilename, err)
+	} else {
+		// configure global logger to output to this file
+		log.SetOutput(f)
+	}
+	return nil
 }
 
 func SetOutputToTerminal() {


### PR DESCRIPTION
* log command-line to log, e.g. `$ fk key create`
* log all `out.Print` output
* don't log passwords (use a special character to suppress certain lines)