### PR TITLE
Implement `fk team create <name>`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ MAIN_GO_FILES=fluidkeys/main.go \
 	     fluidkeys/privatekeys.go \
 	     fluidkeys/ui.go \
 	     fluidkeys/keyfromgpg.go \
+	     fluidkeys/teamcreate.go \
 
 # `make compile` should populate build/ with all files that will
 # ultimately be installed to PREFIX (/usr/local), for example

--- a/fluidkeys/init.go
+++ b/fluidkeys/init.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"os"
 
+	"path/filepath"
+
 	"github.com/fluidkeys/fluidkeys/config"
 	"github.com/fluidkeys/fluidkeys/database"
 	"github.com/fluidkeys/fluidkeys/gpgwrapper"
 	"github.com/fluidkeys/fluidkeys/keyring"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/mitchellh/go-homedir"
-	"path/filepath"
 )
 
 func init() {

--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fluidkeys/fluidkeys/fingerprint"
+
 	"github.com/fluidkeys/fluidkeys/backupzip"
 	"github.com/fluidkeys/fluidkeys/colour"
 	"github.com/fluidkeys/fluidkeys/humanize"
@@ -50,7 +52,7 @@ func keyCreate() exitCode {
 	return 0
 }
 
-func createKeyForEmail(email string) {
+func createKeyForEmail(email string) fingerprint.Fingerprint {
 	channel := make(chan generatePgpKeyResult)
 	go generatePgpKey(email, channel)
 
@@ -98,6 +100,7 @@ func createKeyForEmail(email string) {
 
 	printSuccess("Successfully created key for " + email)
 	out.Print("\n")
+	return fingerprint
 }
 
 func generatePgpKey(email string, channel chan generatePgpKeyResult) {

--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -19,7 +19,6 @@ import (
 
 const DicewareNumberOfWords int = 6
 const DicewareSeparator string = "."
-const PromptEmail string = "Enter your email address, this will help other people find your key.\n"
 
 type DicewarePassword struct {
 	words     []string
@@ -46,7 +45,12 @@ func keyCreate() exitCode {
 		promptForInput("Press enter to continue. ")
 	}
 	out.Print("\n")
-	email := promptForEmail()
+	email := promptForEmail("Enter your email address, this will help other people find your key.\n")
+	createKeyForEmail(email)
+	return 0
+}
+
+func createKeyForEmail(email string) {
 	channel := make(chan generatePgpKeyResult)
 	go generatePgpKey(email, channel)
 
@@ -94,7 +98,6 @@ func keyCreate() exitCode {
 
 	printSuccess("Successfully created key for " + email)
 	out.Print("\n")
-	return 0
 }
 
 func generatePgpKey(email string, channel chan generatePgpKeyResult) {
@@ -103,8 +106,8 @@ func generatePgpKey(email string, channel chan generatePgpKeyResult) {
 	channel <- generatePgpKeyResult{key, err}
 }
 
-func promptForEmail() string {
-	out.Print(PromptEmail + "\n")
+func promptForEmail(promptMessage string) string {
+	out.Print(promptMessage + "\n")
 	return promptForInput("[email] : ")
 }
 

--- a/fluidkeys/keyfromgpg.go
+++ b/fluidkeys/keyfromgpg.go
@@ -40,11 +40,7 @@ func keyFromGpg() exitCode {
 		return 0
 	}
 
-	db.RecordFingerprintImportedIntoGnuPG(keyToImport.Fingerprint)
-	Config.SetStorePassword(keyToImport.Fingerprint, false)
-	Config.SetMaintainAutomatically(keyToImport.Fingerprint, false)
-	printSuccess("Successfully connected key to Fluidkeys")
-	out.Print("\n")
+	importGPGKey(keyToImport.Fingerprint)
 
 	key, err := loadPgpKey(keyToImport.Fingerprint)
 	if err != nil {
@@ -63,6 +59,17 @@ func keyFromGpg() exitCode {
 	out.Print("    " + colour.CommandLineCode("fk key maintain --dry-run") + "\n\n")
 
 	return 0
+}
+
+// importGPGKey records that a fingerprint is now maintained by Fluidkeys. We
+// don't store the password, nor set it to maintain automatically as this feels
+// a little like overreaching.
+func importGPGKey(fingerprint fingerprint.Fingerprint) {
+	db.RecordFingerprintImportedIntoGnuPG(fingerprint)
+	Config.SetStorePassword(fingerprint, false)
+	Config.SetMaintainAutomatically(fingerprint, false)
+	printSuccess("Successfully connected key to Fluidkeys")
+	out.Print("\n")
 }
 
 // keysAvailableToGetFromGpg returns a filtered slice of SecretKeyListings, removing

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -45,6 +45,7 @@ Usage:
 	fk key list
 	fk key maintain [--dry-run]
 	fk key maintain automatic [--cron-output]
+	fk team create <name>
 
 Options:
 	-h --help         Show this screen
@@ -59,11 +60,13 @@ Options:
 
 	ensureCrontabStateMatchesConfig()
 
-	switch getSubcommand(args, []string{"key"}) {
+	switch getSubcommand(args, []string{"key", "team"}) {
 	case "init":
 		os.Exit(initSubcommand(args))
 	case "key":
 		os.Exit(keySubcommand(args))
+	case "team":
+		os.Exit(teamSubcommand(args))
 	}
 }
 
@@ -135,6 +138,18 @@ func keySubcommand(args docopt.Opts) exitCode {
 		os.Exit(keyMaintain(dryRun, automatic, cronOutput))
 	}
 	panic(fmt.Errorf("keySubcommand got unexpected arguments: %v", args))
+}
+
+func teamSubcommand(args docopt.Opts) exitCode {
+	switch getSubcommand(args, []string{
+		"create",
+	}) {
+	case "create":
+		teamName := args["<name>"].(string)
+		fmt.Println(teamName)
+		os.Exit(0)
+	}
+	panic(fmt.Errorf("teamSubCommand got unexpected arguments: %v", args))
 }
 
 func loadPgpKeys() ([]pgpkey.PgpKey, error) {

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -146,8 +146,7 @@ func teamSubcommand(args docopt.Opts) exitCode {
 	}) {
 	case "create":
 		teamName := args["<name>"].(string)
-		fmt.Println(teamName)
-		os.Exit(0)
+		os.Exit(teamCreate(teamName))
 	}
 	panic(fmt.Errorf("teamSubCommand got unexpected arguments: %v", args))
 }

--- a/fluidkeys/teamcreate.go
+++ b/fluidkeys/teamcreate.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fluidkeys/fluidkeys/gpgwrapper"
+
+	"github.com/fluidkeys/fluidkeys/out"
+)
+
+func teamCreate(teamName string) exitCode {
+	out.Print("\n")
+
+	email := promptForEmail("What’s your " + teamName + " email address?\n")
+
+	availableKeys, err := keysAvailableToGetFromGpg()
+	if err != nil {
+		output := fmt.Sprintf("Couldn't retrieve keys from GPG: %v\n", err)
+		out.Print(output)
+		os.Exit(1)
+	}
+
+	existingKey := secretKeyListingsForEmail(availableKeys, email)
+	if existingKey != nil {
+		out.Print("You should use a separate key for each team.\n\n")
+		out.Print(printSecretKeyListing(1, *existingKey))
+		prompter := interactiveYesNoPrompter{}
+		if prompter.promptYesNo("Use this key for "+teamName+"?", "y", nil) {
+			importGPGKey(existingKey.Fingerprint)
+		} else {
+			createKeyForEmail(email)
+		}
+	} else {
+		createKeyForEmail(email)
+	}
+	fmt.Printf("%v\n", existingKey)
+	return 0
+}
+
+func secretKeyListingsForEmail(availableKeys []gpgwrapper.SecretKeyListing, email string) *gpgwrapper.SecretKeyListing {
+	for _, listing := range availableKeys {
+		if (len(listing.Uids) == 1) && (strings.Contains(listing.Uids[0], email)) {
+			return &listing
+		}
+	}
+	return nil
+}

--- a/fluidkeys/teamcreate_test.go
+++ b/fluidkeys/teamcreate_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+	"github.com/fluidkeys/fluidkeys/fingerprint"
+	"github.com/fluidkeys/fluidkeys/gpgwrapper"
+)
+
+func TestSecretKeyListingsForEmail(t *testing.T) {
+	var tests = []struct {
+		availableListings []gpgwrapper.SecretKeyListing
+		email             string
+		expectedToBeFound bool
+		matchingIndex     int
+	}{
+		{
+			[]gpgwrapper.SecretKeyListing{
+				gpgwrapper.SecretKeyListing{
+					Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
+					Uids:        []string{"test@example.com"},
+					Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
+				},
+			},
+			"test@example.com",
+			true,
+			0,
+		},
+		{
+			[]gpgwrapper.SecretKeyListing{
+				gpgwrapper.SecretKeyListing{
+					Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
+					Uids:        []string{"test@example.com", "another@example.com"},
+					Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
+				},
+			},
+			"test@example.com",
+			false,
+			0,
+		},
+		{
+			[]gpgwrapper.SecretKeyListing{
+				gpgwrapper.SecretKeyListing{
+					Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
+					Uids:        []string{"nowhere@example.com"},
+					Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
+				},
+				gpgwrapper.SecretKeyListing{
+					Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
+					Uids:        []string{"Test User <test@example.com>"},
+					Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
+				},
+			},
+			"test@example.com",
+			true,
+			1,
+		},
+	}
+
+	for _, test := range tests {
+		fmt.Printf("Test!\n")
+		t.Run(fmt.Sprintf("secretKeyListingsForEmail(%s)", test.email), func(t *testing.T) {
+			got := secretKeyListingsForEmail(test.availableListings, test.email)
+			fmt.Printf("got != nil? %v\n", (got != nil))
+			if got != nil {
+				if test.expectedToBeFound == false {
+					t.Fatalf("expected not to find an email, but found one!")
+				} else {
+					assert.Equal(t, test.availableListings[test.matchingIndex], *got)
+				}
+			} else {
+				if test.expectedToBeFound == true {
+					t.Fatalf("expected to find an email, but didn't!")
+				}
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
The command prompts the user for an email address for their team, then looks
whether a key exists in GPG with a matching UID. If it finds a matching email,
it prompts the user to import it for use with the team, else it creates a new
key.

The publicKey and teamName are then posted to the team server and the response
parsed to be presented back to the user.

Note: the teamserver domain can be set with the os ENV `TEAMSERVER_URL`, so on
Heroku this should be set to https://api.fluidkeys.com