### PR TITLE
Introduce `fk team show <uuid>`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ MAIN_GO_FILES=fluidkeys/main.go \
 	     fluidkeys/privatekeys.go \
 	     fluidkeys/ui.go \
 	     fluidkeys/keyfromgpg.go \
+	     fluidkeys/teamcreate.go \
 
 # `make compile` should populate build/ with all files that will
 # ultimately be installed to PREFIX (/usr/local), for example

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ MAIN_GO_FILES=fluidkeys/main.go \
 	     fluidkeys/keyfromgpg.go \
 	     fluidkeys/teamcreate.go \
 	     fluidkeys/teamjoin.go \
+	     fluidkeys/teamshow.go \
 
 # `make compile` should populate build/ with all files that will
 # ultimately be installed to PREFIX (/usr/local), for example

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ MAIN_GO_FILES=fluidkeys/main.go \
 	     fluidkeys/ui.go \
 	     fluidkeys/keyfromgpg.go \
 	     fluidkeys/teamcreate.go \
+	     fluidkeys/teamjoin.go \
 
 # `make compile` should populate build/ with all files that will
 # ultimately be installed to PREFIX (/usr/local), for example

--- a/fluidkeys/init.go
+++ b/fluidkeys/init.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"os"
 
+	"path/filepath"
+
 	"github.com/fluidkeys/fluidkeys/config"
 	"github.com/fluidkeys/fluidkeys/database"
 	"github.com/fluidkeys/fluidkeys/gpgwrapper"
 	"github.com/fluidkeys/fluidkeys/keyring"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/mitchellh/go-homedir"
-	"path/filepath"
 )
 
 func init() {

--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fluidkeys/fluidkeys/fingerprint"
+
 	"github.com/fluidkeys/fluidkeys/backupzip"
 	"github.com/fluidkeys/fluidkeys/colour"
 	"github.com/fluidkeys/fluidkeys/humanize"
@@ -50,7 +52,7 @@ func keyCreate() exitCode {
 	return 0
 }
 
-func createKeyForEmail(email string) {
+func createKeyForEmail(email string) fingerprint.Fingerprint {
 	channel := make(chan generatePgpKeyResult)
 	go generatePgpKey(email, channel)
 
@@ -98,6 +100,7 @@ func createKeyForEmail(email string) {
 
 	printSuccess("Successfully created key for " + email)
 	out.Print("\n")
+	return fingerprint
 }
 
 func generatePgpKey(email string, channel chan generatePgpKeyResult) {

--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -19,7 +19,6 @@ import (
 
 const DicewareNumberOfWords int = 6
 const DicewareSeparator string = "."
-const PromptEmail string = "Enter your email address, this will help other people find your key.\n"
 
 type DicewarePassword struct {
 	words     []string
@@ -46,7 +45,12 @@ func keyCreate() exitCode {
 		promptForInput("Press enter to continue. ")
 	}
 	out.Print("\n")
-	email := promptForEmail()
+	email := promptForEmail("Enter your email address, this will help other people find your key.\n")
+	createKeyForEmail(email)
+	return 0
+}
+
+func createKeyForEmail(email string) {
 	channel := make(chan generatePgpKeyResult)
 	go generatePgpKey(email, channel)
 
@@ -94,7 +98,6 @@ func keyCreate() exitCode {
 
 	printSuccess("Successfully created key for " + email)
 	out.Print("\n")
-	return 0
 }
 
 func generatePgpKey(email string, channel chan generatePgpKeyResult) {
@@ -103,8 +106,8 @@ func generatePgpKey(email string, channel chan generatePgpKeyResult) {
 	channel <- generatePgpKeyResult{key, err}
 }
 
-func promptForEmail() string {
-	out.Print(PromptEmail + "\n")
+func promptForEmail(promptMessage string) string {
+	out.Print(promptMessage + "\n")
 	return promptForInput("[email] : ")
 }
 

--- a/fluidkeys/keyfromgpg.go
+++ b/fluidkeys/keyfromgpg.go
@@ -40,11 +40,7 @@ func keyFromGpg() exitCode {
 		return 0
 	}
 
-	db.RecordFingerprintImportedIntoGnuPG(keyToImport.Fingerprint)
-	Config.SetStorePassword(keyToImport.Fingerprint, false)
-	Config.SetMaintainAutomatically(keyToImport.Fingerprint, false)
-	printSuccess("Successfully connected key to Fluidkeys")
-	out.Print("\n")
+	importGPGKey(keyToImport.Fingerprint)
 
 	key, err := loadPgpKey(keyToImport.Fingerprint)
 	if err != nil {
@@ -63,6 +59,17 @@ func keyFromGpg() exitCode {
 	out.Print("    " + colour.CommandLineCode("fk key maintain --dry-run") + "\n\n")
 
 	return 0
+}
+
+// importGPGKey records that a fingerprint is now maintained by Fluidkeys. We
+// don't store the password, nor set it to maintain automatically as this feels
+// a little like overreaching.
+func importGPGKey(fingerprint fingerprint.Fingerprint) {
+	db.RecordFingerprintImportedIntoGnuPG(fingerprint)
+	Config.SetStorePassword(fingerprint, false)
+	Config.SetMaintainAutomatically(fingerprint, false)
+	printSuccess("Successfully connected key to Fluidkeys")
+	out.Print("\n")
 }
 
 // keysAvailableToGetFromGpg returns a filtered slice of SecretKeyListings, removing

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -45,6 +45,7 @@ Usage:
 	fk key list
 	fk key maintain [--dry-run]
 	fk key maintain automatic [--cron-output]
+	fk team create <name>
 
 Options:
 	-h --help         Show this screen
@@ -59,11 +60,13 @@ Options:
 
 	ensureCrontabStateMatchesConfig()
 
-	switch getSubcommand(args, []string{"key"}) {
+	switch getSubcommand(args, []string{"key", "team"}) {
 	case "init":
 		os.Exit(initSubcommand(args))
 	case "key":
 		os.Exit(keySubcommand(args))
+	case "team":
+		os.Exit(teamSubcommand(args))
 	}
 }
 
@@ -135,6 +138,18 @@ func keySubcommand(args docopt.Opts) exitCode {
 		os.Exit(keyMaintain(dryRun, automatic, cronOutput))
 	}
 	panic(fmt.Errorf("keySubcommand got unexpected arguments: %v", args))
+}
+
+func teamSubcommand(args docopt.Opts) exitCode {
+	switch getSubcommand(args, []string{
+		"create",
+	}) {
+	case "create":
+		teamName := args["<name>"].(string)
+		fmt.Println(teamName)
+		os.Exit(0)
+	}
+	panic(fmt.Errorf("teamSubCommand got unexpected arguments: %v", args))
 }
 
 func loadPgpKeys() ([]pgpkey.PgpKey, error) {

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -146,8 +146,7 @@ func teamSubcommand(args docopt.Opts) exitCode {
 	}) {
 	case "create":
 		teamName := args["<name>"].(string)
-		fmt.Println(teamName)
-		os.Exit(0)
+		os.Exit(teamCreate(teamName))
 	}
 	panic(fmt.Errorf("teamSubCommand got unexpected arguments: %v", args))
 }

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -46,6 +46,7 @@ Usage:
 	fk key maintain [--dry-run]
 	fk key maintain automatic [--cron-output]
 	fk team create <name>
+	fk team join <code>
 
 Options:
 	-h --help         Show this screen
@@ -142,11 +143,14 @@ func keySubcommand(args docopt.Opts) exitCode {
 
 func teamSubcommand(args docopt.Opts) exitCode {
 	switch getSubcommand(args, []string{
-		"create",
+		"create", "join",
 	}) {
 	case "create":
 		teamName := args["<name>"].(string)
 		os.Exit(teamCreate(teamName))
+	case "join":
+		teamUuid := args["<code>"].(string)
+		os.Exit(teamJoin(teamUuid))
 	}
 	panic(fmt.Errorf("teamSubCommand got unexpected arguments: %v", args))
 }

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -47,6 +47,7 @@ Usage:
 	fk key maintain automatic [--cron-output]
 	fk team create <name>
 	fk team join <code>
+	fk team show <code>
 
 Options:
 	-h --help         Show this screen
@@ -143,7 +144,7 @@ func keySubcommand(args docopt.Opts) exitCode {
 
 func teamSubcommand(args docopt.Opts) exitCode {
 	switch getSubcommand(args, []string{
-		"create", "join",
+		"create", "join", "show",
 	}) {
 	case "create":
 		teamName := args["<name>"].(string)
@@ -151,6 +152,9 @@ func teamSubcommand(args docopt.Opts) exitCode {
 	case "join":
 		teamUuid := args["<code>"].(string)
 		os.Exit(teamJoin(teamUuid))
+	case "show":
+		teamUuid := args["<code>"].(string)
+		os.Exit(teamShow(teamUuid))
 	}
 	panic(fmt.Errorf("teamSubCommand got unexpected arguments: %v", args))
 }

--- a/fluidkeys/teamcreate.go
+++ b/fluidkeys/teamcreate.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fluidkeys/fluidkeys/gpgwrapper"
+
+	"github.com/fluidkeys/fluidkeys/out"
+)
+
+func teamCreate(teamName string) exitCode {
+	out.Print("\n")
+
+	email := promptForEmail("What’s your " + teamName + " email address?\n")
+
+	availableKeys, err := keysAvailableToGetFromGpg()
+	if err != nil {
+		output := fmt.Sprintf("Couldn't retrieve keys from GPG: %v\n", err)
+		out.Print(output)
+		os.Exit(1)
+	}
+
+	existingKey := secretKeyListingsForEmail(availableKeys, email)
+	if existingKey != nil {
+		out.Print("You should use a separate key for each team.\n\n")
+		out.Print(printSecretKeyListing(1, *existingKey))
+		prompter := interactiveYesNoPrompter{}
+		if prompter.promptYesNo("Use this key for "+teamName+"?", "y", nil) {
+			importGPGKey(existingKey.Fingerprint)
+		} else {
+			createKeyForEmail(email)
+		}
+	} else {
+		createKeyForEmail(email)
+	}
+	fmt.Printf("%v\n", existingKey)
+	return 0
+}
+
+func secretKeyListingsForEmail(availableKeys []gpgwrapper.SecretKeyListing, email string) *gpgwrapper.SecretKeyListing {
+	for _, listing := range availableKeys {
+		if (len(listing.Uids) == 1) && (strings.Contains(listing.Uids[0], email)) {
+			return &listing
+		}
+	}
+	return nil
+}

--- a/fluidkeys/teamcreate.go
+++ b/fluidkeys/teamcreate.go
@@ -47,6 +47,7 @@ func teamCreate(teamName string) exitCode {
 		getTeamServerURL("/teams"),
 		bytes.NewBuffer(teamJSON),
 	)
+	request.Header.Set("User-Agent", "fk-client")
 	request.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}

--- a/fluidkeys/teamcreate_test.go
+++ b/fluidkeys/teamcreate_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+	"github.com/fluidkeys/fluidkeys/fingerprint"
+	"github.com/fluidkeys/fluidkeys/gpgwrapper"
+)
+
+func TestSecretKeyListingsForEmail(t *testing.T) {
+	var tests = []struct {
+		availableListings []gpgwrapper.SecretKeyListing
+		email             string
+		expectedToBeFound bool
+		matchingIndex     int
+	}{
+		{
+			[]gpgwrapper.SecretKeyListing{
+				gpgwrapper.SecretKeyListing{
+					Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
+					Uids:        []string{"test@example.com"},
+					Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
+				},
+			},
+			"test@example.com",
+			true,
+			0,
+		},
+		{
+			[]gpgwrapper.SecretKeyListing{
+				gpgwrapper.SecretKeyListing{
+					Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
+					Uids:        []string{"test@example.com", "another@example.com"},
+					Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
+				},
+			},
+			"test@example.com",
+			false,
+			0,
+		},
+		{
+			[]gpgwrapper.SecretKeyListing{
+				gpgwrapper.SecretKeyListing{
+					Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
+					Uids:        []string{"nowhere@example.com"},
+					Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
+				},
+				gpgwrapper.SecretKeyListing{
+					Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
+					Uids:        []string{"Test User <test@example.com>"},
+					Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
+				},
+			},
+			"test@example.com",
+			true,
+			1,
+		},
+	}
+
+	for _, test := range tests {
+		fmt.Printf("Test!\n")
+		t.Run(fmt.Sprintf("secretKeyListingsForEmail(%s)", test.email), func(t *testing.T) {
+			got := secretKeyListingsForEmail(test.availableListings, test.email)
+			fmt.Printf("got != nil? %v\n", (got != nil))
+			if got != nil {
+				if test.expectedToBeFound == false {
+					t.Fatalf("expected not to find an email, but found one!")
+				} else {
+					assert.Equal(t, test.availableListings[test.matchingIndex], *got)
+				}
+			} else {
+				if test.expectedToBeFound == true {
+					t.Fatalf("expected to find an email, but didn't!")
+				}
+			}
+		})
+	}
+
+}

--- a/fluidkeys/teamjoin.go
+++ b/fluidkeys/teamjoin.go
@@ -1,10 +1,19 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/fluidkeys/fluidkeys/out"
 )
+
+type teamJoinRequestData struct {
+	PublicKey string `json:"publicKey,omitempty"`
+}
 
 func teamJoin(teamUuid string) exitCode {
 	out.Print("\n")
@@ -14,11 +23,88 @@ func teamJoin(teamUuid string) exitCode {
 		return 1
 	}
 
-	out.Print("Valid uuid: " + teamUuid + "\n")
-	return 0
+	teamName, err := getTeamName(teamUuid)
+	if err != nil {
+		out.Print("Error retrieving team name: " + err.Error() + "\n")
+	}
+
+	email := promptForEmail("What’s your " + teamName + " email address?\n")
+
+	armoredPublicKey, err := importOrCreateKeyForEmail(email, teamName)
+	if err != nil {
+		out.Print(err.Error() + "\n")
+		return 1
+	}
+
+	joinRequestData := teamJoinRequestData{
+		PublicKey: armoredPublicKey,
+	}
+
+	joinRequestJSON, err := json.Marshal(joinRequestData)
+	if err != nil {
+		out.Print("Error marshalling JSON: " + err.Error() + "\n")
+		return 1
+	}
+
+	request, err := http.NewRequest(
+		"POST",
+		getTeamServerURL("/teams/"+teamUuid+"/request"),
+		bytes.NewBuffer(joinRequestJSON),
+	)
+	request.Header.Set("User-Agent", "fk-client")
+	request.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+
+	if response.StatusCode == 201 {
+		printSuccess("Successfully requested to join the team\n")
+		out.Print("The team admin will need to approve your request.\n\n")
+		return 0
+	}
+
+	printFailed("Failed to request to join the team")
+	return 1
 }
 
 func isValidUUID(uuid string) bool {
 	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
 	return r.MatchString(uuid)
+}
+
+type teamSummary struct {
+	Name string `json:"teamName"`
+}
+
+func getTeamName(teamUuid string) (string, error) {
+	url := getTeamServerURL("/teams/" + teamUuid + "/summary")
+
+	teamserviceClient := http.Client{
+		Timeout: time.Second * 2, // Maximum of 2 secs
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", "fk-client")
+
+	res, err := teamserviceClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	summary := teamSummary{}
+	err = json.Unmarshal(body, &summary)
+	if err != nil {
+		return "", err
+	}
+
+	return summary.Name, nil
 }

--- a/fluidkeys/teamjoin.go
+++ b/fluidkeys/teamjoin.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"regexp"
+
+	"github.com/fluidkeys/fluidkeys/out"
+)
+
+func teamJoin(teamUuid string) exitCode {
+	out.Print("\n")
+
+	if !isValidUUID(teamUuid) {
+		printFailed("Invalid invite code: " + teamUuid + "\n")
+		return 1
+	}
+
+	out.Print("Valid uuid: " + teamUuid + "\n")
+	return 0
+}
+
+func isValidUUID(uuid string) bool {
+	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
+	return r.MatchString(uuid)
+}

--- a/fluidkeys/teamshow.go
+++ b/fluidkeys/teamshow.go
@@ -85,7 +85,8 @@ func teamShow(teamUUID string) exitCode {
 	out.Print("\n")
 
 	out.Print("To approve these requests run:\n")
-	out.Print("    " + colour.CommandLineCode("fk team approve "+strings.Join(requestEmails, " ")) + "\n\n")
+	cmd := "fk team approve " + teamUUID + " " + strings.Join(requestEmails, " ")
+	out.Print("    " + colour.CommandLineCode(cmd) + "\n\n")
 
 	return 0
 }

--- a/fluidkeys/teamshow.go
+++ b/fluidkeys/teamshow.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/fluidkeys/fluidkeys/colour"
+	"github.com/fluidkeys/fluidkeys/out"
+	"github.com/fluidkeys/fluidkeys/pgpkey"
+)
+
+type Team struct {
+	ID           string         `json:"id,omitempty"`
+	Name         string         `json:"teamName,omitempty"`
+	UUID         string         `json:"uuid,omitempty"`
+	Members      []*Member      `json:"members,omitempty"`
+	JoinRequests []*JoinRequest `json:"joinRequests,omitempty"`
+}
+
+type JoinRequest struct {
+	PublicKey string `json:"publicKey,omitempty"`
+}
+
+type Member struct {
+	PublicKey string `json:"publicKey,omitempty"`
+	IsAdmin   bool   `json:"isAdmin,omitempty"`
+}
+
+func teamShow(teamUUID string) exitCode {
+	out.Print("\n")
+
+	if !isValidUUID(teamUUID) {
+		printFailed("Invalid team code: " + teamUUID + "\n")
+		return 1
+	}
+
+	team, err := getTeamSummary(teamUUID)
+	if err != nil {
+		out.Print("Error: " + err.Error() + "\n\n")
+		return 1
+	}
+
+	out.Print(team.Name + "\n\n")
+
+	out.Print("Members:\n")
+
+	for _, member := range team.Members {
+		key, err := pgpkey.LoadFromArmoredPublicKey(member.PublicKey)
+		if err != nil {
+			out.Print("Error: " + err.Error() + "\n\n")
+			return 1
+		}
+		email, err := key.Email()
+		if err != nil {
+			out.Print("Error: " + err.Error() + "\n\n")
+			return 1
+		}
+		line := email
+		if member.IsAdmin {
+			line = line + "  (Admin)"
+		}
+		printInfo(line)
+	}
+	out.Print("\n")
+
+	requestEmails := []string{}
+	out.Print("Requests to join:\n")
+	for _, requests := range team.JoinRequests {
+		key, err := pgpkey.LoadFromArmoredPublicKey(requests.PublicKey)
+		if err != nil {
+			out.Print("Error: " + err.Error() + "\n\n")
+			return 1
+		}
+		email, err := key.Email()
+		if err != nil {
+			out.Print("Error: " + err.Error() + "\n\n")
+			return 1
+		}
+		printInfo(email + " | " + key.Fingerprint().String())
+		requestEmails = append(requestEmails, email)
+	}
+	out.Print("\n")
+
+	out.Print("To approve these requests run:\n")
+	out.Print("    " + colour.CommandLineCode("fk team approve "+strings.Join(requestEmails, " ")) + "\n\n")
+
+	return 0
+}
+
+func getTeamSummary(teamUUID string) (*Team, error) {
+	url := getTeamServerURL("/teams/" + teamUUID)
+
+	teamserviceClient := http.Client{
+		Timeout: time.Second * 2, // Maximum of 2 secs
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", "fk-client")
+
+	res, err := teamserviceClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	team := Team{}
+	err = json.Unmarshal(body, &team)
+	if err != nil {
+		return nil, err
+	}
+
+	return &team, nil
+}


### PR DESCRIPTION
This hits the teamserver and returns a list of members and requests to join.

In our design document, we specified that the command would be `team show` (without the `uuid` argument), as far as I can tell we've a few options as to how we'd like to solve that but I've paused to talk it through with you first @paulfurley. We might want to record which teams people are in within their `db.json` file - or perhaps another trip to the team server.

I figured in the meantime, I'd get it in working with the `uuid` arg. (The same will apply for the `approve` subcommand).

TODO: Rebase after https://github.com/fluidkeys/fluidkeys/pull/209, https://github.com/fluidkeys/fluidkeys/pull/208