### PR TITLE
Don't support compile from clone outside GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,22 +24,8 @@ MAIN_GO_FILES=fluidkeys/main.go \
 compile: clean build/bin/fk
 
 
-TMPGOPATH := $(shell mktemp -d)
-
 build/bin/fk: $(MAIN_GO_FILES)
-	@mkdir -p build/bin
-	@echo "Creating temporary GOPATH $(TMPGOPATH)"
-
-	rsync -raz $(PWD)/vendor/ $(TMPGOPATH)/src
-
-	mkdir -p $(TMPGOPATH)/src/github.com/fluidkeys
-	ln -s $(PWD) $(TMPGOPATH)/src/github.com/fluidkeys/fluidkeys
-
-	GOPATH=$(TMPGOPATH) go build -o $@ $(MAIN_GO_FILES)
-
-.PHONY: dev
-dev: $(MAIN_GO_FILES)
-	go build -o build/bin/fk $(MAIN_GO_FILES)
+	go build -o $@ $(MAIN_GO_FILES)
 
 .PHONY: test
 test:
@@ -63,8 +49,8 @@ release:
 
 .PHONY: clean
 clean:
-	rm -rf build
-	mkdir -p build
+	@rm -rf build
+	@mkdir -p build
 
 ifeq (${FLUIDKEYS_APT_ID_RSA},)
 $(SECRETS_ID_RSA):

--- a/README.md
+++ b/README.md
@@ -19,20 +19,22 @@ You'll need the [Go compiler](https://golang.org/dl/)
 Clone the repo:
 
 ```
-git clone https://github.com/fluidkeys/fluidkeys.git $HOME/go/src/github.com/fluidkeys/fluidkeys
-cd $HOME/go/src/github.com/fluidkeys/fluidkeys
+REPODIR=$(go env GOPATH)/src/github.com/fluidkeys/fluidkeys
+
+git clone https://github.com/fluidkeys/fluidkeys.git $REPODIR
+cd $REPODIR
 ```
 
 Build and install to `/usr/local/bin/fk`:
 
 ```
-sudo make install
+make && sudo make install
 ```
 
-If you prefer to run without `sudo` (root), install into `$HOME/fluidkeys/bin/fk`:
+If you prefer to run without `sudo` (root), install into `$HOME/bin/fk`:
 
 ```
-PREFIX=$HOME/fluidkeys make install
+PREFIX=$HOME make install
 ```
 
 ## Develop

--- a/script/test_make_compile
+++ b/script/test_make_compile
@@ -1,20 +1,14 @@
 #!/bin/sh -eu
 
+# Note: don't try and compile outside of $GOPATH. It only lead to misery.
+# This used to test that `make compile` could be run from anywhere, but it's
+# not worth the hassle.
+
 THIS_FILE=$0
 THIS_DIR=$(dirname $0)
 
-PREFIX_DIR=$(mktemp -d)
-
-copy_repo_to_random_directory() {
-    TEMP_REPO_DIR=$(mktemp -d)
-
-    cp -R "${THIS_DIR}/../"  "${TEMP_REPO_DIR}"
-}
-
-run_make_compile_without_goroot_or_gopath() {
-    cd "${TEMP_REPO_DIR}"
-    GOROOT="" GOPATH="" PREFIX=${PREFIX_DIR} make compile || exit 1
-    cd -
+test_make_compile_runs() {
+    make compile || exit 1
 }
 
 ensure_fk_binary_exists_in_build() {
@@ -27,7 +21,6 @@ print_success() {
     echo 'OK: `make compile` ran successfully'
 }
 
-copy_repo_to_random_directory
-run_make_compile_without_goroot_or_gopath
+test_make_compile_runs
 ensure_fk_binary_exists_in_build
 print_success


### PR DESCRIPTION
I tried for a long time to ensure `make compile` works *even if* you've
cloned the repo outside your GOPATH. This has caused a lot of problems
and I'm giving up.

This was to make it easy for external compile scripts like Jenkins and
Homebrew. I suspect this is going to break our deployment, so we'll have
to figure out how to fix them separately.