### PR TITLE
Guard tryToPublishKeyAndSetAllowSearchByEmail

### DIFF
--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -178,6 +178,14 @@ func promptAndPublishToFluidkeysDirectory(privateKey *pgpkey.PgpKey) {
 }
 
 func tryToPublishKeyAndSetAllowSearchByEmail(privateKey *pgpkey.PgpKey) error {
+	if privateKey.PrivateKey == nil {
+		return fmt.Errorf("no private key for primary key")
+	}
+
+	if privateKey.PrivateKey.Encrypted {
+		return fmt.Errorf("private key for primary key is encrypted")
+	}
+
 	err := keyPublish(privateKey)
 	if err != nil {
 		return fmt.Errorf("Couldn't publish key: %s", err)


### PR DESCRIPTION
Ensure it gets passed a the private key or returns an error.

I was getting the following on the test suite:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x42a4346]

goroutine 6 [running]:
testing.tRunner.func1(0xc000335400)
	/usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:792 +0x387
panic(0x433b640, 0x466ed00)
	/usr/local/Cellar/go/1.11.1/libexec/src/runtime/panic.go:513 +0x1b9
github.com/fluidkeys/fluidkeys/vendor/github.com/fluidkeys/crypto/openpgp/clearsign.EncodeMulti(0x4408ec0, 0xc0004184d0, 0xc00000e440, 0x1, 0x1, 0x0, 0x70, 0x436b740, 0xc00044bb01, 0xc0004184d0)
	/Users/idrysdale/go/src/github.com/fluidkeys/fluidkeys/vendor/github.com/fluidkeys/crypto/openpgp/clearsign/clearsign.go:317 +0x56
github.com/fluidkeys/fluidkeys/vendor/github.com/fluidkeys/crypto/openpgp/clearsign.Encode(0x4408ec0, 0xc0004184d0, 0x0, 0x0, 0x0, 0xc0, 0xb7, 0xc0)
	/Users/idrysdale/go/src/github.com/fluidkeys/fluidkeys/vendor/github.com/fluidkeys/crypto/openpgp/clearsign/clearsign.go:309 +0x80
github.com/fluidkeys/fluidkeys/api.signText(0xc000450000, 0xb7, 0xc0, 0xc0000b7310, 0xc0, 0x0, 0x0, 0x10000000000000c)
	/Users/idrysdale/go/src/github.com/fluidkeys/fluidkeys/api/api.go:204 +0x65
github.com/fluidkeys/fluidkeys/api.makeUpsertPublicKeySignedData(0xc0000acc00, 0x3f5, 0xc0000b7310, 0xc000442000, 0x3f5, 0xc0000acc00, 0xc0000a7df8)
	/Users/idrysdale/go/src/github.com/fluidkeys/fluidkeys/api/api.go:192 +0x3e0
github.com/fluidkeys/fluidkeys/api.(*Client).UpsertPublicKey(0xc0003ce3a0, 0xc0000acc00, 0x3f5, 0xc0000b7310, 0x0, 0x0)
	/Users/idrysdale/go/src/github.com/fluidkeys/fluidkeys/api/api.go:150 +0x5a
github.com/fluidkeys/fluidkeys/fluidkeys.keyPublish(0xc0000b7310, 0x4500901, 0xc0000b7310)
	/Users/idrysdale/go/src/github.com/fluidkeys/fluidkeys/fluidkeys/keypublish.go:31 +0xc3
github.com/fluidkeys/fluidkeys/fluidkeys.tryToPublishKeyAndSetAllowSearchByEmail(0xc0000b7310, 0x50b, 0xc0000b7310)
	/Users/idrysdale/go/src/github.com/fluidkeys/fluidkeys/fluidkeys/keycreate.go:182 +0x40
github.com/fluidkeys/fluidkeys/fluidkeys.TestTryToPublishKeyAndSetAllowSearchByEmail.func1(0xc000335400)
	/Users/idrysdale/go/src/github.com/fluidkeys/fluidkeys/fluidkeys/keycreate_test.go:19 +0xa5
testing.tRunner(0xc000335400, 0x43c52f0)
```