### PR TITLE
Revert "Guard tryToPublishKeyAndSetAllowSearchByEmail"

### DIFF
--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -178,14 +178,6 @@ func promptAndPublishToFluidkeysDirectory(prompter promptYesNoInterface, private
 }
 
 func tryToPublishKeyAndSetPublishToAPI(privateKey *pgpkey.PgpKey) error {
-	if privateKey.PrivateKey == nil {
-		return fmt.Errorf("no private key for primary key")
-	}
-
-	if privateKey.PrivateKey.Encrypted {
-		return fmt.Errorf("private key for primary key is encrypted")
-	}
-
 	err := keyPublish(privateKey)
 	if err != nil {
 		return fmt.Errorf("Couldn't publish key: %s", err)


### PR DESCRIPTION
This reverts commit 1475e25585446038d5d84fb49e3e774c52a64533.

This wasn't supposed to be added here: we guard elsewhere in `signText`:
d47c19fbef2d6f67bb03e1d8d06e0