### PR TITLE
Refactor publish to API inside key maintain

### DIFF
--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -171,17 +170,4 @@ func userConfirmedRandomWord(password DicewarePassword) bool {
 
 func clearScreen() {
 	out.Print("\033[H\033[2J")
-}
-
-func promptAndTurnOnPublishToAPI(prompter promptYesNoInterface, key *pgpkey.PgpKey) {
-	out.Print("🔍 Publishing your key in the Fluidkeys directory allows\n")
-	out.Print("   others to find your key from your email address.\n\n")
-
-	if prompter.promptYesNo(promptPublishToAPI, "", key) == true {
-		if err := Config.SetPublishToAPI(key.Fingerprint(), true); err != nil {
-			log.Printf("Failed to enable publish to api: %v", err)
-		}
-	} else {
-		out.Print(colour.Disabled(" ▸   Not publishing key to API.\n\n"))
-	}
 }

--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -118,7 +118,13 @@ func keyCreate() exitCode {
 	promptAndTurnOnPublishToAPI(&prompter, generateJob.pgpKey)
 
 	if Config.ShouldPublishToAPI(generateJob.pgpKey.Fingerprint()) {
-		keyPublish(generateJob.pgpKey)
+		err := publishKeyToAPI(generateJob.pgpKey)
+		if err != nil {
+			printFailed("Failed to publish key")
+			out.Print(err.Error())
+		} else {
+			printSuccess("Successfully published key")
+		}
 	}
 	out.Print("\n")
 

--- a/fluidkeys/keymaintain.go
+++ b/fluidkeys/keymaintain.go
@@ -221,7 +221,13 @@ func runKeyMaintain(keys []pgpkey.PgpKey, prompter promptYesNoInterface, passwor
 		}
 
 		if Config.ShouldPublishToAPI(keyTask.key.Fingerprint()) {
-			keyPublish(keyTask.key)
+			err := publishKeyToAPI(keyTask.key)
+			if err != nil {
+				printFailed("Failed to publish key")
+				out.Print(err.Error())
+			} else {
+				printSuccess("Published key to API")
+			}
 		}
 	}
 

--- a/fluidkeys/keymaintain.go
+++ b/fluidkeys/keymaintain.go
@@ -216,9 +216,12 @@ func runKeyMaintain(keys []pgpkey.PgpKey, prompter promptYesNoInterface, passwor
 		if ranActionsSuccesfully && !Config.ShouldMaintainAutomatically(keyTask.key.Fingerprint()) {
 			promptAndTurnOnMaintainAutomatically(prompter, *keyTask)
 		}
+		if ranActionsSuccesfully && !Config.ShouldPublishToAPI(keyTask.key.Fingerprint()) {
+			promptAndTurnOnPublishToAPI(prompter, keyTask.key)
+		}
 
-		if ranActionsSuccesfully {
-			promptAndPublishToFluidkeysDirectory(prompter, keyTask.key)
+		if Config.ShouldPublishToAPI(keyTask.key.Fingerprint()) {
+			keyPublish(keyTask.key)
 		}
 	}
 

--- a/fluidkeys/keymaintain.go
+++ b/fluidkeys/keymaintain.go
@@ -79,7 +79,7 @@ func runKeyMaintainDryRun(keys []pgpkey.PgpKey) exitCode {
 
 	for i := range keyTasks {
 		var keyTask *keyTask = keyTasks[i]
-		keyTask.actions = addImportExportActions(keyTask.actions, nil)
+		addImportExportActions(keyTask, nil)
 		out.Print(formatKeyWarnings(*keyTask))
 		out.Print(formatKeyActions(*keyTask))
 	}
@@ -195,7 +195,7 @@ func runKeyMaintain(keys []pgpkey.PgpKey, prompter promptYesNoInterface, passwor
 
 	for i := range keyTasks {
 		var keyTask *keyTask = keyTasks[i]
-		keyTask.actions = addImportExportActions(keyTask.actions, passwordPrompter)
+		addImportExportActions(keyTask, passwordPrompter)
 	}
 
 	var backupCreatedAlready bool = false
@@ -247,11 +247,10 @@ func runKeyMaintain(keys []pgpkey.PgpKey, prompter promptYesNoInterface, passwor
 	}
 }
 
-func addImportExportActions(actions []status.KeyAction, passwordPrompter promptForPasswordInterface) []status.KeyAction {
-	actions = prepend(actions, LoadPrivateKeyFromGnupg{passwordGetter: passwordPrompter})
-	actions = append(actions, PushIntoGnupg{})
-	actions = append(actions, UpdateBackupZIP{})
-	return actions
+func addImportExportActions(keytask *keyTask, passwordPrompter promptForPasswordInterface) {
+	keytask.actions = prepend(keytask.actions, LoadPrivateKeyFromGnupg{passwordGetter: passwordPrompter})
+	keytask.actions = append(keytask.actions, PushIntoGnupg{})
+	keytask.actions = append(keytask.actions, UpdateBackupZIP{})
 }
 
 func prepend(actions []status.KeyAction, actionToPrepend status.KeyAction) []status.KeyAction {

--- a/fluidkeys/keypublish.go
+++ b/fluidkeys/keypublish.go
@@ -19,7 +19,10 @@ package main
 
 import (
 	"fmt"
+	"log"
 
+	"github.com/fluidkeys/fluidkeys/colour"
+	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 )
 
@@ -33,4 +36,17 @@ func publishKeyToAPI(privateKey *pgpkey.PgpKey) error {
 
 	}
 	return nil
+}
+
+func promptAndTurnOnPublishToAPI(prompter promptYesNoInterface, key *pgpkey.PgpKey) {
+	out.Print("🔍 Publishing your key in the Fluidkeys directory allows\n")
+	out.Print("   others to find your key from your email address.\n\n")
+
+	if prompter.promptYesNo(promptPublishToAPI, "", key) == true {
+		if err := Config.SetPublishToAPI(key.Fingerprint(), true); err != nil {
+			log.Printf("Failed to enable publish to api: %v", err)
+		}
+	} else {
+		out.Print(colour.Disabled(" ▸   Not publishing key to API.\n\n"))
+	}
 }

--- a/fluidkeys/keypublish.go
+++ b/fluidkeys/keypublish.go
@@ -47,6 +47,6 @@ func promptAndTurnOnPublishToAPI(prompter promptYesNoInterface, key *pgpkey.PgpK
 			log.Printf("Failed to enable publish to api: %v", err)
 		}
 	} else {
-		out.Print(colour.Disabled(" ▸   Not publishing key to API.\n\n"))
+		out.Print(colour.Disabled(" ▸   Not publishing key to Fluidkeys directory.\n\n"))
 	}
 }

--- a/fluidkeys/keypublish.go
+++ b/fluidkeys/keypublish.go
@@ -23,7 +23,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 )
 
-func keyPublish(privateKey *pgpkey.PgpKey) error {
+func publishKeyToAPI(privateKey *pgpkey.PgpKey) error {
 	armoredPublicKey, err := privateKey.Armor()
 	if err != nil {
 		return fmt.Errorf("Couldn't load armored key: %s\n", err)


### PR DESCRIPTION
* Separate out setting config and publishing key

* add PublishKeyToAPI KeyAction, no prompt in maintain
  instead of running custom code inside `key maintain`, just insert another
  KeyAction (similar to BackupToZIP) if the config allows.

* Check error on (keyPublish) > publishKeyToAPI and print

* reword "API" -> "Fluidkeys directory"

* move promptAndTurnOnPublishToAPI