### PR TITLE
WIP: Don't log content of secret snippet

### DIFF
--- a/fluidkeys/secretreceive.go
+++ b/fluidkeys/secretreceive.go
@@ -127,8 +127,8 @@ func downloadAndDecryptSecrets(key pgpkey.PgpKey) (decryptedSecrets []string, se
 }
 
 func formatSecretListItem(listNumber int, decryptedContent string) (output string) {
-	displayCounter := fmt.Sprintf("%d. ", listNumber)
-	trimmedDivider := strings.Repeat(secretDividerRune, secretDividerLength-len(displayCounter))
+	displayCounter := fmt.Sprintf(out.NoLogCharacter+" %d. ", listNumber)
+	trimmedDivider := strings.Repeat(secretDividerRune, secretDividerLength-(1+len([]rune(displayCounter))))
 	output = displayCounter + trimmedDivider + "\n"
 	output = output + decryptedContent
 	if !strings.HasSuffix(decryptedContent, "\n") {

--- a/out/out.go
+++ b/out/out.go
@@ -90,11 +90,14 @@ func splitIntoLogLines(message string) []string {
 	for _, line := range strings.Split(message, "\n") {
 		if strings.Trim(line, "\n") == "" {
 			continue
-		} else if strings.Contains(line, NoLogCharacter) {
-			line = "*** line redacted from log file ***"
 		}
 		outLines = append(outLines, line)
 	}
+
+	if strings.Contains(message, NoLogCharacter) {
+		outLines = []string{fmt.Sprintf("*** %d lines redacted from log file ***", len(outLines))}
+	}
+
 	return outLines
 }
 


### PR DESCRIPTION
* out.Print: redact *all* lines with NoLogCharacter

  out.Print gets a multi-line `message`, redact the whole message rather than
  just the single line containing the NoLogCharacter.
  
  This allows us to insert the NoLogCharacter in the header line of the
  secret snippet, without having to modify the actual secret lines at all
  (good for copy/pasting etc)

* [WIP] add NoLogCharacter to secret snippet output

  Note that I've used a "1+" fudge factor here
  
  * `len(NoLogCharacter) = 4` (bytes)
  * `len([]rune(NoLogCharacter)) = 1` (rune)
  * actual *display width* in characters = 2
  
  This isn't very elegant. I'm currently not sure how to calculate the length
  a better way.