### PR TITLE
set KeychainName to "login" on macOS Keychain

### DIFF
--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -35,6 +35,7 @@ func load(allowedBackends []externalkeyring.BackendType) (*Keyring, error) {
 	ring, backendType, err := externalkeyring.Open(externalkeyring.Config{
 		ServiceName:     keyringServiceName,
 		AllowedBackends: allowedBackends,
+		KeychainName:    "login",
 	})
 
 	if err != nil && backendType == externalkeyring.InvalidBackend {


### PR DESCRIPTION
When running from crontab *without* forcing the Keychain to "login", the
keyring comes back with no password because it defaults to looking in
the *system* keyring.