### PR TITLE
find gpg2 binary from fixed PATHs

### DIFF
--- a/fluidkeys/init.go
+++ b/fluidkeys/init.go
@@ -77,7 +77,13 @@ func initDatabase() {
 }
 
 func initGpgWrapper() {
-	gpg = gpgwrapper.GnuPG{}
+	gpgPointer, err := gpgwrapper.Load()
+	if err != nil {
+		fmt.Printf("Failed to load GnuPG: %v\n", err)
+		os.Exit(4)
+	} else {
+		gpg = *gpgPointer
+	}
 }
 
 func initOutput() {

--- a/gpgwrapper/backup_test.go
+++ b/gpgwrapper/backup_test.go
@@ -15,7 +15,7 @@ func TestBackupHomeDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error making temp fluidkeys directory: %v\n", err)
 	}
-	gpg := GnuPG{homeDir: makeTempGnupgHome(t)}
+	gpg := makeGpgWithTempHome(t)
 
 	filename, _ := gpg.BackupHomeDir(tmpFilePath, now)
 

--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -280,7 +280,7 @@ func (g *GnuPG) run(arguments ...string) (string, error) {
 	out, err := exec.Command(g.fullGpgPath, fullArguments...).CombinedOutput()
 
 	if err != nil {
-		err := ErrProblemExecutingGPG(fmt.Sprintf("%v, %s", err,string(out)), fullArguments...)
+		err := ErrProblemExecutingGPG(string(out), fullArguments...)
 		return "", err
 	}
 	outString := string(out)

--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -36,18 +36,6 @@ import (
 
 const GpgPath = "gpg2"
 
-const (
-	publicHeader              = "-----BEGIN PGP PUBLIC KEY BLOCK-----"
-	publicFooter              = "-----END PGP PUBLIC KEY BLOCK-----"
-	privateHeader             = "-----BEGIN PGP PRIVATE KEY BLOCK-----"
-	privateFooter             = "-----END PGP PRIVATE KEY BLOCK-----"
-	nothingExported           = "WARNING: nothing exported"
-	invalidOptionPinentryMode = `gpg: invalid option "--pinentry-mode"`
-	loopbackUnsupported       = `setting pinentry mode 'loopback' failed: Not supported`
-	badPassphrase             = "Bad passphrase"
-	noPassphrase              = "No passphrase given"
-)
-
 var ErrNoVersionStringFound = errors.New("version string not found in GPG output")
 var ErrNoHomeDirectoryStringFound = errors.New("home directory string not found in GPG output")
 
@@ -354,3 +342,15 @@ func (g *GnuPG) prependGlobalArguments(arguments ...string) []string {
 	}
 	return append(globalArguments, arguments...)
 }
+
+const (
+	publicHeader              = "-----BEGIN PGP PUBLIC KEY BLOCK-----"
+	publicFooter              = "-----END PGP PUBLIC KEY BLOCK-----"
+	privateHeader             = "-----BEGIN PGP PRIVATE KEY BLOCK-----"
+	privateFooter             = "-----END PGP PRIVATE KEY BLOCK-----"
+	nothingExported           = "WARNING: nothing exported"
+	invalidOptionPinentryMode = `gpg: invalid option "--pinentry-mode"`
+	loopbackUnsupported       = `setting pinentry mode 'loopback' failed: Not supported`
+	badPassphrase             = "Bad passphrase"
+	noPassphrase              = "No passphrase given"
+)

--- a/gpgwrapper/gpgwrapper_test.go
+++ b/gpgwrapper/gpgwrapper_test.go
@@ -35,9 +35,9 @@ func TestParseGPGOutputVersion(t *testing.T) {
 }
 
 func TestHomeDir(t *testing.T) {
-	t.Run("test default home directory", func(t *testing.T) {
-		expectedDirectory := makeTempGnupgHome(t)
-		gpg := GnuPG{homeDir: expectedDirectory}
+	t.Run("test HomeDir parses correct GNUPGHOME from gpg output", func(t *testing.T) {
+		gpg := makeGpgWithTempHome(t)
+		expectedDirectory := gpg.homeDir // this will be the temp dir
 
 		gotDirectory, err := gpg.HomeDir()
 		if err != nil {
@@ -49,7 +49,7 @@ func TestHomeDir(t *testing.T) {
 }
 
 func TestRunningGPG(t *testing.T) {
-	gpg := GnuPG{homeDir: makeTempGnupgHome(t)}
+	gpg := makeGpgWithTempHome(t)
 
 	t.Run("with valid arguments", func(t *testing.T) {
 		arguments := "--version"
@@ -73,7 +73,7 @@ func TestRunningGPG(t *testing.T) {
 }
 
 func TestRunGpgWithStdin(t *testing.T) {
-	gpg := GnuPG{homeDir: makeTempGnupgHome(t)}
+	gpg := makeGpgWithTempHome(t)
 
 	t.Run("with a valid public key", func(t *testing.T) {
 		successMessages := []string{
@@ -105,7 +105,7 @@ func TestRunGpgWithStdin(t *testing.T) {
 }
 
 func TestImportPublicKey(t *testing.T) {
-	gpg := GnuPG{homeDir: makeTempGnupgHome(t)}
+	gpg := makeGpgWithTempHome(t)
 
 	t.Run("with valid public key", func(t *testing.T) {
 		_, err := gpg.ImportArmoredKey(ExamplePublicKey)
@@ -120,7 +120,7 @@ func TestImportPublicKey(t *testing.T) {
 
 func TestListSecretKeys(t *testing.T) {
 
-	gpg := GnuPG{homeDir: makeTempGnupgHome(t)}
+	gpg := makeGpgWithTempHome(t)
 	gpg.ImportArmoredKey(ExamplePublicKey)
 	gpg.ImportArmoredKey(ExamplePrivateKey)
 	secretKeys, err := gpg.ListSecretKeys()
@@ -143,7 +143,7 @@ func TestListSecretKeys(t *testing.T) {
 }
 
 func TestExportPublicKey(t *testing.T) {
-	gpg := GnuPG{homeDir: makeTempGnupgHome(t)}
+	gpg := makeGpgWithTempHome(t)
 	gpg.ImportArmoredKey(ExamplePublicKey)
 	gpg.ImportArmoredKey(ExamplePrivateKey)
 
@@ -166,7 +166,7 @@ func TestExportPublicKey(t *testing.T) {
 }
 
 func TestExportPrivateKey(t *testing.T) {
-	gpg := GnuPG{homeDir: makeTempGnupgHome(t)}
+	gpg := makeGpgWithTempHome(t)
 	gpg.ImportArmoredKey(ExamplePublicKey)
 	gpg.ImportArmoredKey(ExamplePrivateKey)
 
@@ -371,6 +371,13 @@ func assertEqual(t *testing.T, expected SecretKeyListing, got SecretKeyListing) 
 			t.Fatalf("uids don't match, expected '%v', got '%v'", expected.Uids, got.Uids)
 		}
 	}
+}
+
+func makeGpgWithTempHome(t *testing.T) GnuPG {
+	gpgBinary, err := findGpgBinary()
+	assert.ErrorIsNil(t, err)
+
+	return GnuPG{fullGpgPath: gpgBinary, homeDir: makeTempGnupgHome(t)}
 }
 
 func makeTempGnupgHome(t *testing.T) string {


### PR DESCRIPTION
* search for gpg binary in predefined directories
  Don't use PATH as this is a route for an attacker to manipulate Fluidkeys
  into revealing a password to a (fake) gpg binary by manipulating PATH
* make gpgwrapper.Load, add GnuPG.fullGpgPath
* make makeGpgWithTempHome test helper
* move constants to bottom of file