### PR TITLE
Allow optional email to be passed to setup

### DIFF
--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -54,7 +54,9 @@ type generatePgpKeyResult struct {
 	err    error
 }
 
-func keyCreate() (exitCode, *pgpkey.PgpKey) {
+// keyCreate creates a new pgp key and returns it.
+// If email is empty, it prompts the user for an email address
+func keyCreate(email string) (exitCode, *pgpkey.PgpKey) {
 
 	if !gpg.IsWorking() {
 		out.Print(colour.Warning("\nGPG isn't working on your system 🤒\n\n"))
@@ -66,16 +68,23 @@ func keyCreate() (exitCode, *pgpkey.PgpKey) {
 	}
 	out.Print("\n")
 
-	printHeader("What's your email address?")
+	if email == "" {
+		printHeader("What's your email address?")
 
-	out.Print("This is how other people using Fluidkeys will find you.\n\n")
-	out.Print("We'll send you an email to verify your address.\n\n")
+		out.Print("This is how other people using Fluidkeys will find you.\n\n")
+		out.Print("We'll send you an email to verify your address.\n\n")
 
-	email := promptForInput("[email] : ")
-	for !emailutils.RoughlyValidateEmail(email) {
-		printWarning("Not a valid email address")
-		out.Print("\n")
-		email = promptForInput("[email] : ")
+		email := promptForInput("[email] : ")
+		for !emailutils.RoughlyValidateEmail(email) {
+			printWarning("Not a valid email address")
+			out.Print("\n")
+			email = promptForInput("[email] : ")
+		}
+	} else {
+		printHeader("Setting up " + email)
+
+		out.Print("Other people using Fluidkeys will find you at " + email + ".\n\n")
+		out.Print("We'll send you an email to verify your address.\n\n")
 	}
 
 	channel := make(chan generatePgpKeyResult)

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -62,7 +62,8 @@ func main() {
 Configuration file: %s
 
 Usage:
-	fk setup [<email>]
+	fk setup
+	fk setup <email>
 	fk secret send <recipient-email-address>
 	fk secret receive
 	fk key create
@@ -260,8 +261,13 @@ func secretSubcommand(args docopt.Opts) exitCode {
 }
 
 func setupSubcommand(args docopt.Opts) exitCode {
-	email, _ := args.String("<email>")
-	// Have to swallow error, as docopts returns `err: key: "<email>" failed type conversion`
+	if args["<email>"] == nil {
+		return setup("")
+	}
+	email, err := args.String("<email>")
+	if err != nil {
+		log.Panic(err)
+	}
 	if email != "" && !emailutils.RoughlyValidateEmail(email) {
 		printFailed(email + " isn't a valid email address")
 		return 1

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/fluidkeys/fluidkeys/emailutils"
 	"github.com/fluidkeys/fluidkeys/keytable"
 	"github.com/fluidkeys/fluidkeys/status"
 
@@ -61,7 +62,7 @@ func main() {
 Configuration file: %s
 
 Usage:
-	fk setup
+	fk setup [<email>]
 	fk secret send <recipient-email-address>
 	fk secret receive
 	fk key create
@@ -135,7 +136,7 @@ func keySubcommand(args docopt.Opts) exitCode {
 		"create", "from-gpg", "list", "maintain", "publish",
 	}) {
 	case "create":
-		exitCode, _ := keyCreate()
+		exitCode, _ := keyCreate("")
 		os.Exit(exitCode)
 	case "from-gpg":
 		os.Exit(keyFromGpg())
@@ -259,5 +260,11 @@ func secretSubcommand(args docopt.Opts) exitCode {
 }
 
 func setupSubcommand(args docopt.Opts) exitCode {
-	return setup()
+	email, _ := args.String("<email>")
+	// Have to swallow error, as docopts returns `err: key: "<email>" failed type conversion`
+	if email != "" && !emailutils.RoughlyValidateEmail(email) {
+		printFailed(email + " isn't a valid email address")
+		return 1
+	}
+	return setup(email)
 }

--- a/fluidkeys/setup.go
+++ b/fluidkeys/setup.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/out"
 )
 
-func setup() exitCode {
+func setup(email string) exitCode {
 	out.Print("\n")
 
 	out.Print(colour.Greeting(paulAndIanGreeting) + "\n")
@@ -18,7 +18,7 @@ func setup() exitCode {
 
 	out.Print("Fluidkeys makes it easy to send end-to-end encrypted secrets using PGP.\n")
 
-	exitCode, pgpKey := keyCreate()
+	exitCode, pgpKey := keyCreate(email)
 	if exitCode != 0 {
 		return exitCode
 	}
@@ -30,7 +30,7 @@ func setup() exitCode {
 		return 1
 	}
 
-	email, err := pgpKey.Email()
+	email, err = pgpKey.Email()
 	if err != nil {
 		printFailed("Couldn't get email address for key:")
 		out.Print("Error: " + err.Error() + "\n")


### PR DESCRIPTION
This will allow us to direct people to install Fluidkeys by running:
```
fk setup ian@example.com
```

Something odd appears to be happening with docopts. `fk setup [<email>]`
should allow an optional argument `email` to be passed to `setup`, however,
args.String("<email>") returns an error.