### PR TITLE
`key publish` > `key upload`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ MAIN_GO_FILES=fluidkeys/main.go \
 	     fluidkeys/secretsend.go \
 	     fluidkeys/secretreceive.go \
 	     fluidkeys/setup.go \
-	     fluidkeys/keypublish.go \
+	     fluidkeys/keyupload.go \
 
 # `make compile` should populate build/ with all files that will
 # ultimately be installed to PREFIX (/usr/local), for example

--- a/fluidkeys/keymaintain.go
+++ b/fluidkeys/keymaintain.go
@@ -235,10 +235,12 @@ func runKeyMaintain(keys []pgpkey.PgpKey, prompter promptYesNoInterface, passwor
 		}
 		if numKeysNotPublished > 0 {
 
-			out.Print(fmt.Sprintf(" " + colour.Warning("▸   "+humanize.Pluralize(numKeysNotPublished, "key hasn't", "keys haven't")+
-				" been updated in the Fluidkeys directory.\n\n")))
-			out.Print("Make sure others can find your updated keys by running:\n")
-			out.Print("    " + colour.CommandLineCode("fk key publish") + "\n\n")
+			out.Print(
+				fmt.Sprintf(" " + colour.Warning("▸   "+
+					humanize.Pluralize(numKeysNotPublished, "key hasn't", "keys haven't")+
+					" been uploaded to Fluidkeys.\n\n")))
+			out.Print("Make sure others can send you secrets by running:\n")
+			out.Print("    " + colour.CommandLineCode("fk key upload") + "\n\n")
 		}
 
 		return 0
@@ -542,7 +544,7 @@ type PublishToAPI struct {
 }
 
 func (a PublishToAPI) String() string {
-	return "Publish updated key to Fluidkeys directory"
+	return "Upload updated key to Fluidkeys"
 }
 
 func (a PublishToAPI) Enact(key *pgpkey.PgpKey, now time.Time, password *string) error {

--- a/fluidkeys/main.go
+++ b/fluidkeys/main.go
@@ -69,7 +69,7 @@ Usage:
 	fk key list
 	fk key maintain [--dry-run]
 	fk key maintain automatic [--cron-output]
-	fk key publish
+	fk key upload
 
 Options:
 	-h --help         Show this screen
@@ -132,7 +132,7 @@ func getSubcommand(args docopt.Opts, subcommands []string) string {
 
 func keySubcommand(args docopt.Opts) exitCode {
 	switch getSubcommand(args, []string{
-		"create", "from-gpg", "list", "maintain", "publish",
+		"create", "from-gpg", "list", "maintain", "upload",
 	}) {
 	case "create":
 		exitCode, _ := keyCreate()
@@ -155,8 +155,8 @@ func keySubcommand(args docopt.Opts) exitCode {
 			log.Panic(err)
 		}
 		os.Exit(keyMaintain(dryRun, automatic, cronOutput))
-	case "publish":
-		os.Exit(keyPublish())
+	case "upload":
+		os.Exit(keyUpload())
 	}
 	log.Panicf("keySubcommand got unexpected arguments: %v", args)
 	panic(nil)

--- a/fluidkeys/secretreceive.go
+++ b/fluidkeys/secretreceive.go
@@ -53,7 +53,7 @@ func secretReceive() exitCode {
 
 	for _, key := range keys {
 		if !Config.ShouldPublishToAPI(key.Fingerprint()) {
-			message := "Not published in Fluidkeys directory"
+			message := "Key not uploaded to Fluidkeys, can't receive secrets"
 			out.Print("⛔ " + displayName(&key) + ": " + colour.Warning(message) + "\n")
 			continue
 		}

--- a/keytable/keytable.go
+++ b/keytable/keytable.go
@@ -222,7 +222,8 @@ func makePrimaryInstruction(keysWithWarnings []KeyWithWarnings) string {
 		} else { // These aren't urgent issues
 			output = "Fix these issues by running:\n"
 		}
-		output += "    " + colour.CommandLineCode("fk key maintain") + "\n\n"
+		output += "    " + colour.CommandLineCode("fk key maintain") + "\n"
+		output += "    " + colour.CommandLineCode("fk key upload") + "\n\n"
 	}
 	return output
 }

--- a/status/keywarning.go
+++ b/status/keywarning.go
@@ -144,10 +144,10 @@ func (w KeyWarning) String() string {
 		return "Key not maintained automatically"
 
 	case ConfigPublishToAPINotSet:
-		return "Key not published in the Fluidkeys directory"
+		return "Key not uploaded, unable to receive secrets"
 
 	case ConfigMaintainAutomaticallyButDontPublish:
-		return "Key maintained automatically but not published"
+		return "Key maintained automatically but not uploaded, unable to receive secrets"
 	}
 
 	return fmt.Sprintf("KeyWarning{Type=%d}", w.Type)

--- a/status/keywarning_test.go
+++ b/status/keywarning_test.go
@@ -80,11 +80,11 @@ func TestString(t *testing.T) {
 		},
 		{
 			KeyWarning{Type: ConfigPublishToAPINotSet},
-			"Key not published in the Fluidkeys directory",
+			"Key not uploaded, unable to receive secrets",
 		},
 		{
 			KeyWarning{Type: ConfigMaintainAutomaticallyButDontPublish},
-			"Key maintained automatically but not published",
+			"Key maintained automatically but not uploaded, unable to receive secrets",
 		},
 		{
 			KeyWarning{}, // unspecified type


### PR DESCRIPTION
You upload your key to Fluidkeys, so that you can receive secrets.

We don't talk about publishing because it implies it's being made public,
it's only available to be searched by email.