### PR TITLE
don't make keys with an empty email address

### DIFF
--- a/fluidkeys/keycreate.go
+++ b/fluidkeys/keycreate.go
@@ -74,7 +74,7 @@ func keyCreate(email string) (exitCode, *pgpkey.PgpKey) {
 		out.Print("This is how other people using Fluidkeys will find you.\n\n")
 		out.Print("We'll send you an email to verify your address.\n\n")
 
-		email := promptForInput("[email] : ")
+		email = promptForInput("[email] : ")
 		for !emailutils.RoughlyValidateEmail(email) {
 			printWarning("Not a valid email address")
 			out.Print("\n")


### PR DESCRIPTION
the `:=` operator meant `email` was shadowing the command-line argument
`email`

(Damn I wish Go would fail on *all* shadowing, this so reminds me of C++
days)