### PR TITLE
Improve GnuPG log output

### DIFF
--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -79,7 +79,7 @@ func Load() (*GnuPG, error) {
 
 // Returns the GnuPG version string, e.g. "1.2.3"
 func (g *GnuPG) Version() (string, error) {
-	outString, err := g.run("--version")
+	outString, _, err := g.runWithStdin("", "--version")
 
 	if err != nil {
 		err = fmt.Errorf("problem running GPG, %v", err)
@@ -98,7 +98,7 @@ func (g *GnuPG) Version() (string, error) {
 
 // Returns the GnuPG home directory, e.g. "/Users/jane/.gnupg"
 func (g *GnuPG) HomeDir() (string, error) {
-	outString, err := g.run("--version")
+	outString, _, err := g.runWithStdin("", "--version")
 	if err != nil {
 		err = fmt.Errorf("problem running GPG, %v", err)
 		return "", err
@@ -147,7 +147,7 @@ func (g *GnuPG) ListSecretKeys() ([]SecretKeyListing, error) {
 		"--fixed-list-mode",
 		"--list-secret-keys",
 	}
-	outString, err := g.run(args...)
+	outString, _, err := g.runWithStdin("", args...)
 	if err != nil {
 		return nil, fmt.Errorf("error running 'gpg %s': %v", strings.Join(args, " "), err)
 	}
@@ -165,7 +165,7 @@ func (g *GnuPG) ExportPublicKey(fingerprint fingerprint.Fingerprint) (string, er
 		fingerprint.Hex(),
 	}
 
-	stdout, err := g.run(args...)
+	stdout, _, err := g.runWithStdin("", args...)
 	if err != nil {
 		return "", err
 	}

--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -197,7 +197,7 @@ func (g *GnuPG) ExportPrivateKey(fingerprint fingerprint.Fingerprint, password s
 	)
 
 	if err != nil {
-		if strings.Contains(stderr, invalidOptionPinentryMode) { // TODO: is this really in stderr or in stdout?
+		if strings.Contains(stderr, invalidOptionPinentryMode) {
 			stdout, stderr, err := g.runWithStdin(
 				password,
 				getArgsExportPrivateKeyWithoutPinentry(fingerprint)...,

--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -294,12 +294,6 @@ func (g *GnuPG) runWithStdin(textToSend string, arguments ...string) (
 	fullArguments := g.prependGlobalArguments(arguments...)
 	cmd := exec.Command(g.fullGpgPath, fullArguments...)
 
-	stdin, err := cmd.StdinPipe() // used to send textToSend
-	if err != nil {
-		returnErr = fmt.Errorf("Failed to get stdin pipe '%s'", err)
-		return
-	}
-
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		returnErr = fmt.Errorf("Failed to get stdout pipe '%s'", err)
@@ -311,8 +305,16 @@ func (g *GnuPG) runWithStdin(textToSend string, arguments ...string) (
 		return
 	}
 
-	io.WriteString(stdin, textToSend)
-	stdin.Close()
+	if textToSend != "" {
+		stdin, err := cmd.StdinPipe() // used to send textToSend
+		if err != nil {
+			returnErr = fmt.Errorf("Failed to get stdin pipe '%s'", err)
+			return
+		}
+
+		io.WriteString(stdin, textToSend)
+		stdin.Close()
+	}
 
 	if err = cmd.Start(); err != nil {
 		returnErr = fmt.Errorf("error starting gpg: %v", err)

--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -82,7 +82,6 @@ func (g *GnuPG) Version() (string, error) {
 	outString, _, err := g.run("", "--version")
 
 	if err != nil {
-		err = fmt.Errorf("problem running GPG, %v", err)
 		return "", err
 	}
 
@@ -100,7 +99,6 @@ func (g *GnuPG) Version() (string, error) {
 func (g *GnuPG) HomeDir() (string, error) {
 	outString, _, err := g.run("", "--version")
 	if err != nil {
-		err = fmt.Errorf("problem running GPG, %v", err)
 		return "", err
 	}
 
@@ -131,7 +129,6 @@ func (g *GnuPG) IsWorking() bool {
 func (g *GnuPG) ImportArmoredKey(armoredKey string) (string, error) {
 	stdout, stderr, err := g.run(armoredKey, "--import")
 	if err != nil {
-		err = fmt.Errorf("problem importing key, %v", err)
 		return stderr, err
 	}
 	// TODO: are we correctly checking if GPG failed? I think it can return
@@ -149,7 +146,7 @@ func (g *GnuPG) ListSecretKeys() ([]SecretKeyListing, error) {
 	}
 	outString, _, err := g.run("", args...)
 	if err != nil {
-		return nil, fmt.Errorf("error running 'gpg %s': %v", strings.Join(args, " "), err)
+		return nil, err
 	}
 
 	return parseListSecretKeys(outString)

--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -289,7 +289,8 @@ func (g *GnuPG) run(arguments ...string) (string, error) {
 
 // runWithStdin runs the given command, sends textToSend via stdin, and returns
 // stdout, stderr and any error encountered
-func (g *GnuPG) runWithStdin(textToSend string, arguments ...string) (stdout string, stderr string, returnErr error) {
+func (g *GnuPG) runWithStdin(textToSend string, arguments ...string) (
+	stdout string, stderr string, returnErr error) {
 	fullArguments := g.prependGlobalArguments(arguments...)
 	cmd := exec.Command(g.fullGpgPath, fullArguments...)
 

--- a/gpgwrapper/gpgwrapper_test.go
+++ b/gpgwrapper/gpgwrapper_test.go
@@ -53,13 +53,13 @@ func TestRunGpgWithStdin(t *testing.T) {
 
 	t.Run("with empty stdin (but valid arguments)", func(t *testing.T) {
 		arguments := "--version"
-		_, _, err := gpg.runWithStdin("", arguments)
+		_, _, err := gpg.run("", arguments)
 		assertNoError(t, err)
 	})
 
 	t.Run("with invalid arguments", func(t *testing.T) {
 		arguments := "--foo"
-		_, _, err := gpg.runWithStdin("", arguments)
+		_, _, err := gpg.run("", arguments)
 		if err == nil {
 			t.Fatalf("wanted an error but didn't get one")
 		}
@@ -79,7 +79,7 @@ func TestRunGpgWithStdin(t *testing.T) {
 
 		arguments := []string{"--import"}
 
-		_, stderr, err := gpg.runWithStdin(ExamplePublicKey, arguments...)
+		_, stderr, err := gpg.run(ExamplePublicKey, arguments...)
 
 		if err != nil {
 			t.Errorf("Test failed, returned error %s", err)


### PR DESCRIPTION
* GnuPG.run(..): if gpg returns an error, return a more descriptive error message, and log
  all stderr lines to debug.log

* combine .run(..) and runWithStdin(..) into single method