### PR TITLE
gpg.ImportArmoredKey: return err not (stdout, err)

### DIFF
--- a/fluidkeys/privatekeys.go
+++ b/fluidkeys/privatekeys.go
@@ -77,11 +77,11 @@ func pushPrivateKeyBackToGpg(
 		return fmt.Errorf("failed to dump private key: %v\n", err)
 	}
 
-	_, err = importer.ImportArmoredKey(armoredPublicKey)
+	err = importer.ImportArmoredKey(armoredPublicKey)
 	if err != nil {
 		return err
 	}
 
-	_, err = importer.ImportArmoredKey(armoredPrivateKey)
+	err = importer.ImportArmoredKey(armoredPrivateKey)
 	return err
 }

--- a/fluidkeys/privatekeys_test.go
+++ b/fluidkeys/privatekeys_test.go
@@ -21,12 +21,11 @@ func (m *mockExportPrivateKey) ExportPrivateKey(fingerprint fingerprint.Fingerpr
 }
 
 type mockImportArmoredKey struct {
-	returnString string
-	returnError  error
+	returnError error
 }
 
-func (m *mockImportArmoredKey) ImportArmoredKey(armoredKey string) (string, error) {
-	return m.returnString, m.returnError
+func (m *mockImportArmoredKey) ImportArmoredKey(armoredKey string) error {
+	return m.returnError
 }
 
 type mockLoadFromArmoredEncryptedPrivateKey struct {
@@ -206,8 +205,7 @@ func TestPushPrivateKeyBackToGpg(t *testing.T) {
 		}
 
 		mockImporter := mockImportArmoredKey{
-			returnString: "",
-			returnError:  nil,
+			returnError: nil,
 		}
 
 		err := pushPrivateKeyBackToGpg(&mockKey, "[irrelevant]", &mockImporter)
@@ -223,8 +221,7 @@ func TestPushPrivateKeyBackToGpg(t *testing.T) {
 		}
 
 		mockImporter := mockImportArmoredKey{
-			returnString: "",
-			returnError:  nil,
+			returnError: nil,
 		}
 		err := pushPrivateKeyBackToGpg(&mockKey, "[irrelevant]", &mockImporter)
 		assert.ErrorIsNotNil(t, err)
@@ -239,8 +236,7 @@ func TestPushPrivateKeyBackToGpg(t *testing.T) {
 		}
 
 		mockImporter := mockImportArmoredKey{
-			returnString: "",
-			returnError:  nil,
+			returnError: nil,
 		}
 		err := pushPrivateKeyBackToGpg(&mockKey, "[irrelevant]", &mockImporter)
 		assert.ErrorIsNotNil(t, err)
@@ -255,8 +251,7 @@ func TestPushPrivateKeyBackToGpg(t *testing.T) {
 		}
 
 		mockImporter := mockImportArmoredKey{
-			returnString: "",
-			returnError:  fmt.Errorf("some error in ImportedArmoredKey"),
+			returnError: fmt.Errorf("some error in ImportedArmoredKey"),
 		}
 		err := pushPrivateKeyBackToGpg(&mockKey, "[irrelevant]", &mockImporter)
 		assert.ErrorIsNotNil(t, err)

--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -126,15 +126,15 @@ func (g *GnuPG) IsWorking() bool {
 }
 
 // Import an armored key into the GPG key ring
-func (g *GnuPG) ImportArmoredKey(armoredKey string) (string, error) {
-	stdout, stderr, err := g.run(armoredKey, "--import")
+func (g *GnuPG) ImportArmoredKey(armoredKey string) error {
+	_, _, err := g.run(armoredKey, "--import")
 	if err != nil {
-		return stderr, err
+		return err
 	}
 	// TODO: are we correctly checking if GPG failed? I think it can return
 	// exit code 0 *but* set stderr to communicate a problem
 
-	return stdout, nil
+	return nil
 }
 
 func (g *GnuPG) ListSecretKeys() ([]SecretKeyListing, error) {

--- a/gpgwrapper/gpgwrapper_test.go
+++ b/gpgwrapper/gpgwrapper_test.go
@@ -104,12 +104,12 @@ func TestImportPublicKey(t *testing.T) {
 	gpg := makeGpgWithTempHome(t)
 
 	t.Run("with valid public key", func(t *testing.T) {
-		_, err := gpg.ImportArmoredKey(ExamplePublicKey)
+		err := gpg.ImportArmoredKey(ExamplePublicKey)
 		assertNoError(t, err)
 	})
 
 	t.Run("with valid private key", func(t *testing.T) {
-		_, err := gpg.ImportArmoredKey(ExamplePrivateKey)
+		err := gpg.ImportArmoredKey(ExamplePrivateKey)
 		assertNoError(t, err)
 	})
 }

--- a/gpgwrapper/interfaces.go
+++ b/gpgwrapper/interfaces.go
@@ -26,5 +26,5 @@ type ExportPrivateKeyInterface interface {
 }
 
 type ImportArmoredKeyInterface interface {
-	ImportArmoredKey(string) (string, error)
+	ImportArmoredKey(string) error
 }


### PR DESCRIPTION
I'm not sure why this was ever being returned. It doesn't contain anything
very useful, and it was never used by any callers!