### PR TITLE
only modify crontab when actually necessary

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -82,26 +82,16 @@ func getCurrentCrontab() (string, error) {
 }
 
 func writeCrontab(newCrontab string) error {
-	if isEmptyCrontab(newCrontab) {
-		_, err := runCrontab("-r") // remove the user's crontab
-		return err
-	} else {
-		f, err := ioutil.TempFile("", "")
-		if err != nil {
-			return err
-		}
-
-		f.Write([]byte(newCrontab))
-		f.Close()
-
-		_, err = runCrontab(f.Name())
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
 		return err
 	}
-}
 
-func isEmptyCrontab(crontab string) bool {
-	// TODO: strip newlines
-	return crontab == ""
+	f.Write([]byte(newCrontab))
+	f.Close()
+
+	_, err = runCrontab(f.Name())
+	return err
 }
 
 func isExitStatusOne(err error) bool {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -37,15 +37,10 @@ func Enable() (crontabWasAdded bool, err error) {
 	if !hasFluidkeysCronLines(currentCrontab) {
 		newCrontab := addCrontabLinesWithoutRepeating(currentCrontab)
 		err = writeCrontab(newCrontab)
-		if err != nil {
-			return false, err
-		}
-		crontabWasAdded = true
-	} else {
-		crontabWasAdded = false
+		return true, err
 	}
 
-	return
+	return false, nil
 }
 
 // Disable parses the crontab (output of `crontab -l`) and removes Fluidkeys'
@@ -58,14 +53,11 @@ func Disable() (cronLinesWereRemoved bool, err error) {
 	}
 
 	if hasFluidkeysCronLines(currentCrontab) {
-		cronLinesWereRemoved = true
 		newCrontab := removeCrontabLines(currentCrontab)
 		err = writeCrontab(newCrontab)
-		return
-	} else {
-		cronLinesWereRemoved = false
-		return
+		return true, err
 	}
+	return false, nil
 }
 
 func hasFluidkeysCronLines(crontab string) bool {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -20,6 +20,7 @@ package scheduler
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -104,6 +105,7 @@ func isExitStatusOne(err error) bool {
 }
 
 func runCrontab(arguments ...string) (string, error) {
+	log.Printf("Running `%s %s`", crontab, strings.Join(arguments, " "))
 	cmd := exec.Command(crontab, arguments...)
 
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
e.g. when `run_from_cron = true` and at least one key has `maintain_automatically = true`

Don't go adding ourselves to crontab until there's actually a need to. It's
pretty alarming to do that on the very first command someone types, e.g.
`fk secret send`

This probably isn't the end of the story: we should consider how we explicitly ask to modify
the user's crontab, but I'd like to see whether people find this approach
more reasonable first.

Also, don't use `crontab -r` to delete an empty crontab

if we remove our lines from the crontab and it results in the crontab being
empty, don't use `crontab -r` to remove it, just add an empty crontab.

this helps #274 where `systemd-cron-next` doesn't support `crontab -r`