### PR TITLE
factor out top-level fk code into `fk` package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,7 @@ endif
 
 DEB=pkg/debian
 SECRETS_ID_RSA=.secret/download-fluidkeys-com.id_rsa
-MAIN_GO_FILES=fluidkeys/main.go \
-	     fluidkeys/errors.go \
-	     fluidkeys/init.go \
-	     fluidkeys/keycreate.go \
-	     fluidkeys/keymaintain.go \
-	     fluidkeys/password.go \
-	     fluidkeys/privatekeys.go \
-	     fluidkeys/ui.go \
-	     fluidkeys/keyfromgpg.go \
-	     fluidkeys/secretsend.go \
-	     fluidkeys/secretreceive.go \
-	     fluidkeys/setup.go \
-	     fluidkeys/keyupload.go \
+MAIN_GO_FILES=cmd/fk/main.go
 
 # `make compile` should populate build/ with all files that will
 # ultimately be installed to PREFIX (/usr/local), for example

--- a/cmd/fk/main.go
+++ b/cmd/fk/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Paul Furley and Ian Drysdale
+// Copyright 2019 Paul Furley and Ian Drysdale
 //
 // This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
 //
@@ -17,15 +17,11 @@
 
 package main
 
-type IncorrectPassword struct {
-	message       string
-	originalError string
-}
+import (
+	"github.com/fluidkeys/fluidkeys/fk"
+	"os"
+)
 
-func (e *IncorrectPassword) Error() string {
-	if e.message != "" {
-		return e.message
-	} else {
-		return "the password was incorrect"
-	}
+func main() {
+	os.Exit(fk.Main())
 }

--- a/fk/errors.go
+++ b/fk/errors.go
@@ -1,0 +1,31 @@
+// Copyright 2018 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package fk
+
+type IncorrectPassword struct {
+	message       string
+	originalError string
+}
+
+func (e *IncorrectPassword) Error() string {
+	if e.message != "" {
+		return e.message
+	} else {
+		return "the password was incorrect"
+	}
+}

--- a/fk/init.go
+++ b/fk/init.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/keycreate.go
+++ b/fk/keycreate.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/keycreate_test.go
+++ b/fk/keycreate_test.go
@@ -1,4 +1,4 @@
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/keyfromgpg.go
+++ b/fk/keyfromgpg.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/keymaintain.go
+++ b/fk/keymaintain.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/keyupload.go
+++ b/fk/keyupload.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/main.go
+++ b/fk/main.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"bufio"
@@ -56,7 +56,7 @@ var (
 
 type exitCode = int
 
-func main() {
+func Main() exitCode {
 	usage := fmt.Sprintf(`Fluidkeys %s
 
 Configuration file: %s
@@ -90,11 +90,14 @@ Options:
 
 	switch getSubcommand(args, []string{"key", "secret", "setup"}) {
 	case "key":
-		os.Exit(keySubcommand(args))
+		return keySubcommand(args)
 	case "secret":
-		os.Exit(secretSubcommand(args))
+		return secretSubcommand(args)
 	case "setup":
-		os.Exit(setupSubcommand(args))
+		return setupSubcommand(args)
+	default:
+		out.Print("unhandled subcommand")
+		return 1
 	}
 }
 

--- a/fk/main_test.go
+++ b/fk/main_test.go
@@ -1,4 +1,4 @@
-package main
+package fk
 
 import (
 	"bufio"

--- a/fk/password.go
+++ b/fk/password.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/privatekeys.go
+++ b/fk/privatekeys.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/privatekeys_test.go
+++ b/fk/privatekeys_test.go
@@ -1,4 +1,4 @@
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"bytes"

--- a/fk/secretsend.go
+++ b/fk/secretsend.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"bufio"

--- a/fk/secretsend_test.go
+++ b/fk/secretsend_test.go
@@ -1,4 +1,4 @@
-package main
+package fk
 
 import (
 	"bytes"

--- a/fk/setup.go
+++ b/fk/setup.go
@@ -1,4 +1,4 @@
-package main
+package fk
 
 import (
 	"fmt"

--- a/fk/ui.go
+++ b/fk/ui.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package fk
 
 import (
 	"fmt"


### PR DESCRIPTION
* move all of `fk` code out of `fluidkeys/*.go` (`master` package) and
into `./fk/*.go`
* make a new `cmd/fk/main.go` which *only* passes through to `fk.Main()`
* simplify `Makefile`: build now requires single file `cmd/fk/main.go`