### PR TITLE
Iterate over the secrets on `secret receive`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v0.3.1"
 
 [[projects]]
+  digest = "1:1ca95505ec8a6d69762d2b5d9ab7e66ae619365b2e26031e220b675ff6fb010b"
+  name = "github.com/atotto/clipboard"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "aa9549103943c05f3e8951009cdb6a0bec2c8949"
+  version = "v0.1.1"
+
+[[projects]]
   branch = "master"
   digest = "1:289fa52f4d9e9c817a003324bc14e9339b996dbe02b9f6cfc57a9383e5365287"
   name = "github.com/docopt/docopt-go"
@@ -149,6 +157,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/BurntSushi/toml",
+    "github.com/atotto/clipboard",
     "github.com/docopt/docopt-go",
     "github.com/fluidkeys/api/v1structs",
     "github.com/fluidkeys/crypto/openpgp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -68,3 +68,7 @@
   branch = "master"
   name = "github.com/minimaxir/big-list-of-naughty-strings"
   source = "github.com/fluidkeys/fork-big-list-of-naughty-strings"
+
+[[constraint]]
+  name = "github.com/atotto/clipboard"
+  version = "0.1.1"

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/atotto/clipboard"
 	"github.com/fluidkeys/api/v1structs"
 	"github.com/fluidkeys/fluidkeys/colour"
 	"github.com/fluidkeys/fluidkeys/fingerprint"
@@ -84,6 +85,12 @@ func secretReceive() exitCode {
 
 		for _, secret := range decryptedSecrets {
 			out.Print(formatSecretListItem(secret.decryptedContent))
+			if prompter.promptYesNo("Copy to clipboard?", "", nil) == true {
+				err := clipboard.WriteAll(secret.decryptedContent)
+				if err != nil {
+					printFailed(err.Error())
+				}
+			}
 			if prompter.promptYesNo("Delete now?", "Y", nil) == true {
 				err := client.DeleteSecret(secret.sentToFingerprint, secret.UUID.String())
 				if err != nil {

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -38,7 +38,7 @@ import (
 func secretReceive() exitCode {
 	out.Print("\n")
 	keys, err := loadPgpKeys()
-	var downloadedSecrets []secret
+	prompter := interactiveYesNoPrompter{}
 
 	if err != nil {
 		printFailed("Couldn't load PGP keys")
@@ -84,10 +84,15 @@ func secretReceive() exitCode {
 
 		for _, secret := range decryptedSecrets {
 			out.Print(formatSecretListItem(secret.decryptedContent))
+			if prompter.promptYesNo("Delete now?", "Y", nil) == true {
+				err := client.DeleteSecret(secret.sentToFingerprint, secret.UUID.String())
+				if err != nil {
+					log.Printf("failed to delete secret '%s': %v", secret.UUID, err)
+					printFailed("Error trying to delete secret:")
+					printFailed(err.Error())
+				}
+			}
 		}
-		downloadedSecrets = append(downloadedSecrets, decryptedSecrets...)
-
-		out.Print(strings.Repeat(secretDividerRune, secretDividerLength) + "\n")
 
 		if len(secretErrors) > 0 {
 			output := humanize.Pluralize(len(secretErrors), "secret", "secrets") + " failed to download for " + displayName(&key) + ":\n"
@@ -96,27 +101,6 @@ func secretReceive() exitCode {
 				printFailed(error.Error())
 			}
 			sawError = true
-		}
-	}
-
-	sawErrorDeletingSecret := false
-
-	if len(downloadedSecrets) > 0 {
-		prompter := interactiveYesNoPrompter{}
-		out.Print("\n")
-		if prompter.promptYesNo("Delete now?", "Y", nil) == true {
-			for _, secret := range downloadedSecrets {
-				err := client.DeleteSecret(secret.sentToFingerprint, secret.UUID.String())
-				if err != nil {
-					log.Printf("failed to delete secret '%s': %v", secret.UUID, err)
-					sawErrorDeletingSecret = true
-				}
-			}
-			if sawErrorDeletingSecret {
-				printFailed("One or more errors deleting secrets")
-			} else {
-				printSuccess("Deleted all secrets")
-			}
 		}
 	}
 
@@ -161,6 +145,7 @@ func formatSecretListItem(decryptedContent string) (output string) {
 	if !strings.HasSuffix(decryptedContent, "\n") {
 		output = output + "\n"
 	}
+	output = output + strings.Repeat(secretDividerRune, secretDividerLength) + "\n"
 	return output
 }
 

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -76,10 +76,14 @@ func secretReceive() exitCode {
 		}
 		decryptedSecrets, secretErrors := decryptSecrets(encryptedSecrets, privateKey)
 
-		out.Print("📬 " + displayName(&key) + ":\n")
+		out.Print("📬 " + displayName(&key) + ":\n\n")
 
-		for i, secret := range decryptedSecrets {
-			out.Print(formatSecretListItem(i+1, secret.decryptedContent))
+		secretCount := len(decryptedSecrets)
+
+		out.Print(humanize.Pluralize(secretCount, "secret", "secrets") + ":\n\n")
+
+		for _, secret := range decryptedSecrets {
+			out.Print(formatSecretListItem(secret.decryptedContent))
 		}
 		downloadedSecrets = append(downloadedSecrets, decryptedSecrets...)
 
@@ -150,10 +154,9 @@ func decryptSecrets(encryptedSecrets []v1structs.Secret, privateKey *pgpkey.PgpK
 	return secrets, secretErrors
 }
 
-func formatSecretListItem(listNumber int, decryptedContent string) (output string) {
-	displayCounter := fmt.Sprintf(out.NoLogCharacter+" %d. ", listNumber)
-	trimmedDivider := strings.Repeat(secretDividerRune, secretDividerLength-(1+len([]rune(displayCounter))))
-	output = displayCounter + trimmedDivider + "\n"
+func formatSecretListItem(decryptedContent string) (output string) {
+	trimmedDivider := strings.Repeat(secretDividerRune, secretDividerLength-(1))
+	output = out.NoLogCharacter + trimmedDivider + "\n"
 	output = output + decryptedContent
 	if !strings.HasSuffix(decryptedContent, "\n") {
 		output = output + "\n"

--- a/vendor/github.com/atotto/clipboard/.travis.yml
+++ b/vendor/github.com/atotto/clipboard/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+
+go:
+ - go1.4.3
+ - go1.5.4
+ - go1.6.4
+ - go1.7.6
+ - go1.8.7
+ - go1.9.4
+ - go1.10
+
+before_install:
+ - export DISPLAY=:99.0
+ - sh -e /etc/init.d/xvfb start
+
+script:
+ - sudo apt-get install xsel
+ - go test -v .
+ - sudo apt-get install xclip
+ - go test -v .

--- a/vendor/github.com/atotto/clipboard/LICENSE
+++ b/vendor/github.com/atotto/clipboard/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Ato Araki. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of @atotto. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/atotto/clipboard/README.md
+++ b/vendor/github.com/atotto/clipboard/README.md
@@ -1,0 +1,48 @@
+[![Build Status](https://travis-ci.org/atotto/clipboard.svg?branch=master)](https://travis-ci.org/atotto/clipboard)
+
+[![GoDoc](https://godoc.org/github.com/atotto/clipboard?status.svg)](http://godoc.org/github.com/atotto/clipboard)
+
+# Clipboard for Go
+
+Provide copying and pasting to the Clipboard for Go.
+
+Build:
+
+    $ go get github.com/atotto/clipboard
+
+Platforms:
+
+* OSX
+* Windows 7 (probably work on other Windows)
+* Linux, Unix (requires 'xclip' or 'xsel' command to be installed)
+
+
+Document: 
+
+* http://godoc.org/github.com/atotto/clipboard
+
+Notes:
+
+* Text string only
+* UTF-8 text encoding only (no conversion)
+
+TODO:
+
+* Clipboard watcher(?)
+
+## Commands:
+
+paste shell command:
+
+    $ go get github.com/atotto/clipboard/cmd/gopaste
+    $ # example:
+    $ gopaste > document.txt
+
+copy shell command:
+
+    $ go get github.com/atotto/clipboard/cmd/gocopy
+    $ # example:
+    $ cat document.txt | gocopy
+
+
+

--- a/vendor/github.com/atotto/clipboard/clipboard.go
+++ b/vendor/github.com/atotto/clipboard/clipboard.go
@@ -1,0 +1,20 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package clipboard read/write on clipboard
+package clipboard
+
+// ReadAll read string from clipboard
+func ReadAll() (string, error) {
+	return readAll()
+}
+
+// WriteAll write string to clipboard
+func WriteAll(text string) error {
+	return writeAll(text)
+}
+
+// Unsupported might be set true during clipboard init, to help callers decide
+// whether or not to offer clipboard options.
+var Unsupported bool

--- a/vendor/github.com/atotto/clipboard/clipboard_darwin.go
+++ b/vendor/github.com/atotto/clipboard/clipboard_darwin.go
@@ -1,0 +1,52 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin
+
+package clipboard
+
+import (
+	"os/exec"
+)
+
+var (
+	pasteCmdArgs = "pbpaste"
+	copyCmdArgs  = "pbcopy"
+)
+
+func getPasteCommand() *exec.Cmd {
+	return exec.Command(pasteCmdArgs)
+}
+
+func getCopyCommand() *exec.Cmd {
+	return exec.Command(copyCmdArgs)
+}
+
+func readAll() (string, error) {
+	pasteCmd := getPasteCommand()
+	out, err := pasteCmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func writeAll(text string) error {
+	copyCmd := getCopyCommand()
+	in, err := copyCmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := copyCmd.Start(); err != nil {
+		return err
+	}
+	if _, err := in.Write([]byte(text)); err != nil {
+		return err
+	}
+	if err := in.Close(); err != nil {
+		return err
+	}
+	return copyCmd.Wait()
+}

--- a/vendor/github.com/atotto/clipboard/clipboard_unix.go
+++ b/vendor/github.com/atotto/clipboard/clipboard_unix.go
@@ -1,0 +1,112 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build freebsd linux netbsd openbsd solaris dragonfly
+
+package clipboard
+
+import (
+	"errors"
+	"os/exec"
+)
+
+const (
+	xsel               = "xsel"
+	xclip              = "xclip"
+	termuxClipboardGet = "termux-clipboard-get"
+	termuxClipboardSet = "termux-clipboard-set"
+)
+
+var (
+	Primary bool
+
+	pasteCmdArgs []string
+	copyCmdArgs  []string
+
+	xselPasteArgs = []string{xsel, "--output", "--clipboard"}
+	xselCopyArgs  = []string{xsel, "--input", "--clipboard"}
+
+	xclipPasteArgs = []string{xclip, "-out", "-selection", "clipboard"}
+	xclipCopyArgs  = []string{xclip, "-in", "-selection", "clipboard"}
+
+	termuxPasteArgs = []string{termuxClipboardGet}
+	termuxCopyArgs  = []string{termuxClipboardSet}
+
+	missingCommands = errors.New("No clipboard utilities available. Please install xsel, xclip, or Termux:API add-on for termux-clipboard-get/set.")
+)
+
+func init() {
+	pasteCmdArgs = xclipPasteArgs
+	copyCmdArgs = xclipCopyArgs
+
+	if _, err := exec.LookPath(xclip); err == nil {
+		return
+	}
+
+	pasteCmdArgs = xselPasteArgs
+	copyCmdArgs = xselCopyArgs
+
+	if _, err := exec.LookPath(xsel); err == nil {
+		return
+	}
+
+	pasteCmdArgs = termuxPasteArgs
+	copyCmdArgs = termuxCopyArgs
+
+	if _, err := exec.LookPath(termuxClipboardSet); err == nil {
+		if _, err := exec.LookPath(termuxClipboardGet); err == nil {
+			return
+		}
+	}
+
+	Unsupported = true
+}
+
+func getPasteCommand() *exec.Cmd {
+	if Primary {
+		pasteCmdArgs = pasteCmdArgs[:1]
+	}
+	return exec.Command(pasteCmdArgs[0], pasteCmdArgs[1:]...)
+}
+
+func getCopyCommand() *exec.Cmd {
+	if Primary {
+		copyCmdArgs = copyCmdArgs[:1]
+	}
+	return exec.Command(copyCmdArgs[0], copyCmdArgs[1:]...)
+}
+
+func readAll() (string, error) {
+	if Unsupported {
+		return "", missingCommands
+	}
+	pasteCmd := getPasteCommand()
+	out, err := pasteCmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func writeAll(text string) error {
+	if Unsupported {
+		return missingCommands
+	}
+	copyCmd := getCopyCommand()
+	in, err := copyCmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := copyCmd.Start(); err != nil {
+		return err
+	}
+	if _, err := in.Write([]byte(text)); err != nil {
+		return err
+	}
+	if err := in.Close(); err != nil {
+		return err
+	}
+	return copyCmd.Wait()
+}

--- a/vendor/github.com/atotto/clipboard/clipboard_windows.go
+++ b/vendor/github.com/atotto/clipboard/clipboard_windows.go
@@ -1,0 +1,128 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package clipboard
+
+import (
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+const (
+	cfUnicodetext = 13
+	gmemMoveable  = 0x0002
+)
+
+var (
+	user32           = syscall.MustLoadDLL("user32")
+	openClipboard    = user32.MustFindProc("OpenClipboard")
+	closeClipboard   = user32.MustFindProc("CloseClipboard")
+	emptyClipboard   = user32.MustFindProc("EmptyClipboard")
+	getClipboardData = user32.MustFindProc("GetClipboardData")
+	setClipboardData = user32.MustFindProc("SetClipboardData")
+
+	kernel32     = syscall.NewLazyDLL("kernel32")
+	globalAlloc  = kernel32.NewProc("GlobalAlloc")
+	globalFree   = kernel32.NewProc("GlobalFree")
+	globalLock   = kernel32.NewProc("GlobalLock")
+	globalUnlock = kernel32.NewProc("GlobalUnlock")
+	lstrcpy      = kernel32.NewProc("lstrcpyW")
+)
+
+// waitOpenClipboard opens the clipboard, waiting for up to a second to do so.
+func waitOpenClipboard() error {
+	started := time.Now()
+	limit := started.Add(time.Second)
+	var r uintptr
+	var err error
+	for time.Now().Before(limit) {
+		r, _, err = openClipboard.Call(0)
+		if r != 0 {
+			return nil
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return err
+}
+
+func readAll() (string, error) {
+	err := waitOpenClipboard()
+	if err != nil {
+		return "", err
+	}
+	defer closeClipboard.Call()
+
+	h, _, err := getClipboardData.Call(cfUnicodetext)
+	if h == 0 {
+		return "", err
+	}
+
+	l, _, err := globalLock.Call(h)
+	if l == 0 {
+		return "", err
+	}
+
+	text := syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(l))[:])
+
+	r, _, err := globalUnlock.Call(h)
+	if r == 0 {
+		return "", err
+	}
+
+	return text, nil
+}
+
+func writeAll(text string) error {
+	err := waitOpenClipboard()
+	if err != nil {
+		return err
+	}
+	defer closeClipboard.Call()
+
+	r, _, err := emptyClipboard.Call(0)
+	if r == 0 {
+		return err
+	}
+
+	data := syscall.StringToUTF16(text)
+
+	// "If the hMem parameter identifies a memory object, the object must have
+	// been allocated using the function with the GMEM_MOVEABLE flag."
+	h, _, err := globalAlloc.Call(gmemMoveable, uintptr(len(data)*int(unsafe.Sizeof(data[0]))))
+	if h == 0 {
+		return err
+	}
+	defer func() {
+		if h != 0 {
+			globalFree.Call(h)
+		}
+	}()
+
+	l, _, err := globalLock.Call(h)
+	if l == 0 {
+		return err
+	}
+
+	r, _, err = lstrcpy.Call(l, uintptr(unsafe.Pointer(&data[0])))
+	if r == 0 {
+		return err
+	}
+
+	r, _, err = globalUnlock.Call(h)
+	if r == 0 {
+		if err.(syscall.Errno) != 0 {
+			return err
+		}
+	}
+
+	r, _, err = setClipboardData.Call(cfUnicodetext, h)
+	if r == 0 {
+		return err
+	}
+	h = 0 // suppress deferred cleanup
+	return nil
+}

--- a/vendor/github.com/atotto/clipboard/go.mod
+++ b/vendor/github.com/atotto/clipboard/go.mod
@@ -1,0 +1,1 @@
+module github.com/atotto/clipboard


### PR DESCRIPTION
Following the designs on the [Command Line Google Doc](https://docs.google.com/document/d/1FHQXHP7X8Uvtvn72OqZNVYyFMocrJ2MM1zWtYTM4d0c/#heading=h.435am9i821s9) `secret receive` now prints the number of secrets each key is receiving (and no longer list them numerically). It then iterates over each secret, prompting the user whether they want to copy the contents to the clipboard, then whether they want to delete it.

I opted to introduce https://github.com/atotto/clipboard/ to handle copying to the clipboard. It handles unix, with a friendly error message if they don't have a command
line tool installed:

![screenshot 2019-02-05 at 11 27 11](https://user-images.githubusercontent.com/55195/52273903-15fd9a00-2943-11e9-8948-7a25c8a23dcc.png)
