### PR TITLE
Prompt to save a secret to disk when receiving a file

### DIFF
--- a/colour/colour.go
+++ b/colour/colour.go
@@ -127,6 +127,10 @@ func Waiting(message string) string {
 	return fgCyan + message + reset
 }
 
+func File(filename string) string {
+	return yellow(filename)
+}
+
 func underline(message string) string {
 	return underscore + message + reset
 }

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -237,13 +237,24 @@ func decryptAPISecret(
 	decryptedSecret := secret{
 		decryptedContent: decryptedContent,
 		UUID:             uuid,
-	}
-
-	if !literalData.ForEyesOnly() {
-		decryptedSecret.originalFilename = literalData.FileName
+		originalFilename: populateOriginalFilename(literalData),
 	}
 
 	return &decryptedSecret, nil
+}
+
+func populateOriginalFilename(literalData *packet.LiteralData) string {
+	if literalData.ForEyesOnly() {
+		// don't save to disk: don't return a filename
+		return ""
+	}
+
+	if literalData.FileName != "" {
+		// strip paths, e.g. /home/someone/.bashrc -> `.bashrc`
+		return filepath.Base(literalData.FileName)
+	}
+
+	return ""
 }
 
 func countDigits(i int) (count int) {

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -292,7 +292,7 @@ func getDownloadsDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	downloadsDir := userDir + "/Downloads"
+	downloadsDir := filepath.Join(userDir, "Downloads")
 	fileInfo, err := os.Stat(downloadsDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -339,12 +339,6 @@ type secret struct {
 	UUID             uuid.UUID
 }
 
-type errListSecrets struct {
-	originalError error
-}
-
-func (e errListSecrets) Error() string { return e.originalError.Error() }
-
 type errNoSecretsFound struct{}
 
 func (e errNoSecretsFound) Error() string { return "" }

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -150,7 +150,7 @@ func promptAndWriteToDownloads(secret secret, prompter promptYesNoInterface) err
 	}
 
 	if prompter.promptYesNo("Save to "+filename+"?", "", nil) == true {
-		err := ioutil.WriteFile(filename, []byte(secret.decryptedContent), 0644)
+		err := ioutil.WriteFile(filename, []byte(secret.decryptedContent), 0600)
 
 		if err != nil {
 			return fmt.Errorf("Error writing file %s: %v", filename, err)

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -91,9 +91,11 @@ func secretReceive() exitCode {
 		out.Print(humanize.Pluralize(secretCount, "secret", "secrets") + ":\n\n")
 
 		for _, secret := range decryptedSecrets {
-			out.Print(formatSecretListItem(secret.decryptedContent, secret.filename))
-			if secret.filename != "" {
-				filenameToWrite, err := getFileNameToWrite(secret.filename)
+			out.Print(formatSecretListItem(
+				secret.decryptedContent, secret.originalFilename),
+			)
+			if secret.originalFilename != "" {
+				filenameToWrite, err := getFileNameToWrite(secret.originalFilename)
 				if err != nil {
 					printFailed("Error prompting to save file to disk:")
 					printFailed(err.Error())
@@ -219,7 +221,7 @@ func decryptAPISecret(
 	}
 
 	if !literalData.ForEyesOnly() {
-		decryptedSecret.filename = literalData.FileName
+		decryptedSecret.originalFilename = literalData.FileName
 	}
 
 	return &decryptedSecret, nil
@@ -300,7 +302,11 @@ const (
 
 type secret struct {
 	decryptedContent string
-	filename         string
+
+	// originalFilename should be the (base) filename of the secret file on the sender's
+	// machine, e.g. `secret.txt`.
+	// Warning: don't trust that it's a basename, assume it might be e.g. `/etc/passwd`
+	originalFilename string
 	UUID             uuid.UUID
 }
 

--- a/fk/secretreceive_test.go
+++ b/fk/secretreceive_test.go
@@ -205,7 +205,7 @@ func TestDecryptAPISecret(t *testing.T) {
 		})
 
 		t.Run("with an empty filename", func(t *testing.T) {
-			assert.Equal(t, decryptedSecret.filename, "")
+			assert.Equal(t, decryptedSecret.originalFilename, "")
 		})
 	})
 
@@ -233,7 +233,7 @@ func TestDecryptAPISecret(t *testing.T) {
 		})
 
 		t.Run("with a matching filename", func(t *testing.T) {
-			assert.Equal(t, decryptedSecret.filename, "example.txt")
+			assert.Equal(t, decryptedSecret.originalFilename, "example.txt")
 		})
 	})
 }

--- a/fk/secretreceive_test.go
+++ b/fk/secretreceive_test.go
@@ -239,3 +239,39 @@ func TestDecryptAPISecret(t *testing.T) {
 		})
 	})
 }
+
+func mockDoesntExist(path string) bool {
+	if path == "/fake/new_filename.txt" {
+		return true
+	}
+
+	if path == "/fake/existing_filename.txt" || path == "/fake/existing_filename(1).txt" {
+		return false
+	}
+
+	if path == "/fake/old_filename.txt.bak" {
+		return false
+	}
+
+	return true
+}
+
+func TestGetNewUniqueFilename(t *testing.T) {
+	t.Run("returns the same value if the filename doesn't exist", func(t *testing.T) {
+		filename := getNewUniqueFilename("/fake/new_filename.txt", mockDoesntExist)
+		fmt.Printf("file: %s\n", filename)
+		assert.Equal(t, "new_filename.txt", filename)
+	})
+
+	t.Run("increments a counter to find a filename that doesn't exist", func(t *testing.T) {
+		filename := getNewUniqueFilename("/fake/existing_filename.txt", mockDoesntExist)
+		fmt.Printf("file: %s\n", filename)
+		assert.Equal(t, "existing_filename(2).txt", filename)
+	})
+
+	t.Run("adds the counter before the last file extension", func(t *testing.T) {
+		filename := getNewUniqueFilename("/fake/old_filename.txt.bak", mockDoesntExist)
+		fmt.Printf("file: %s\n", filename)
+		assert.Equal(t, "old_filename.txt(1).bak", filename)
+	})
+}

--- a/fk/secretreceive_test.go
+++ b/fk/secretreceive_test.go
@@ -195,17 +195,17 @@ func TestDecryptAPISecret(t *testing.T) {
 		assert.ErrorIsNil(t, err)
 
 		t.Run("with decrypted content", func(t *testing.T) {
-			assert.Equal(t, decryptedSecret.decryptedContent, "decrypted content")
+			assert.Equal(t, "decrypted content", decryptedSecret.decryptedContent)
 		})
 
 		t.Run("with decrypted uuid", func(t *testing.T) {
-			uuid, err := uuid.FromString("93d5ac5b-74e5-4f87-b117-b8d7576395d8")
+			expectedUuid, err := uuid.FromString("93d5ac5b-74e5-4f87-b117-b8d7576395d8")
 			assert.ErrorIsNil(t, err)
-			assert.Equal(t, decryptedSecret.UUID, uuid)
+			assert.Equal(t, expectedUuid, decryptedSecret.UUID)
 		})
 
 		t.Run("with an empty filename", func(t *testing.T) {
-			assert.Equal(t, decryptedSecret.originalFilename, "")
+			assert.Equal(t, "", decryptedSecret.originalFilename)
 		})
 	})
 
@@ -223,17 +223,17 @@ func TestDecryptAPISecret(t *testing.T) {
 		assert.ErrorIsNil(t, err)
 
 		t.Run("with decrypted content", func(t *testing.T) {
-			assert.Equal(t, decryptedSecret.decryptedContent, "decrypted content")
+			assert.Equal(t, "decrypted content", decryptedSecret.decryptedContent)
 		})
 
 		t.Run("with decrypted uuid", func(t *testing.T) {
-			uuid, err := uuid.FromString("93d5ac5b-74e5-4f87-b117-b8d7576395d8")
+			expectedUuid, err := uuid.FromString("93d5ac5b-74e5-4f87-b117-b8d7576395d8")
 			assert.ErrorIsNil(t, err)
-			assert.Equal(t, decryptedSecret.UUID, uuid)
+			assert.Equal(t, expectedUuid, decryptedSecret.UUID)
 		})
 
 		t.Run("with a matching filename", func(t *testing.T) {
-			assert.Equal(t, decryptedSecret.originalFilename, "example.txt")
+			assert.Equal(t, "example.txt", decryptedSecret.originalFilename)
 		})
 	})
 }

--- a/fk/secretreceive_test.go
+++ b/fk/secretreceive_test.go
@@ -191,9 +191,7 @@ func TestDecryptAPISecret(t *testing.T) {
 				FileName: "_CONSOLE",
 			},
 		}
-		decryptedSecret := secret{}
-
-		err := decryptAPISecret(encryptedSecret, &decryptedSecret, mockPrivateKey)
+		decryptedSecret, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
 		assert.ErrorIsNil(t, err)
 
 		t.Run("with decrypted content", func(t *testing.T) {

--- a/fk/secretreceive_test.go
+++ b/fk/secretreceive_test.go
@@ -216,7 +216,7 @@ func TestDecryptAPISecret(t *testing.T) {
 			),
 			decryptedArmoredToStringResult: "decrypted content",
 			decryptedArmoredToStringLiteralData: &packet.LiteralData{
-				FileName: "example.txt",
+				FileName: "/naughty/absolute/path/example.txt",
 			},
 		}
 		decryptedSecret, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
@@ -232,7 +232,7 @@ func TestDecryptAPISecret(t *testing.T) {
 			assert.Equal(t, expectedUuid, decryptedSecret.UUID)
 		})
 
-		t.Run("with a matching filename", func(t *testing.T) {
+		t.Run("with a matching filename reduced to basename", func(t *testing.T) {
 			assert.Equal(t, "example.txt", decryptedSecret.originalFilename)
 		})
 	})

--- a/pgpkey/decrypt.go
+++ b/pgpkey/decrypt.go
@@ -58,6 +58,9 @@ func (p *PgpKey) DecryptArmoredToString(encrypted string) (string, *packet.Liter
 	if err != nil {
 		return "", nil, err
 	}
+	if literalData.IsBinary {
+		return "", nil, fmt.Errorf("encrypted binaries not allowed")
+	}
 
 	buffer := new(bytes.Buffer)
 	if _, err = buffer.ReadFrom(reader); err != nil {


### PR DESCRIPTION
Following the designs on the [Command Line Google Doc](https://docs.google.com/document/d/1FHQXHP7X8Uvtvn72OqZNVYyFMocrJ2MM1zWtYTM4d0c/#heading=h.435am9i821s9) `secret receive` will now recieve secrets sent as files! 🙌

It will save files in `~\Downloads` and report an error if this directory doesn't exist.

If the file already exists, it'll attempt to increment a counter to find a filepath that doesn't exist. So if trying to download `README.md` and that file already exists, it'll suggest `README(1).md`.

Resulting interface:

![screenshot 2019-02-05 at 17 43 21](https://user-images.githubusercontent.com/55195/52292877-92a56e00-296d-11e9-96b2-8febd4a809b5.png)

Rebase after https://github.com/fluidkeys/fluidkeys/pull/293