### PR TITLE
remove unused secret.sentToFingerprint

### DIFF
--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -92,7 +92,7 @@ func secretReceive() exitCode {
 				}
 			}
 			if prompter.promptYesNo("Delete now?", "Y", nil) == true {
-				err := client.DeleteSecret(secret.sentToFingerprint, secret.UUID.String())
+				err := client.DeleteSecret(key.Fingerprint(), secret.UUID.String())
 				if err != nil {
 					log.Printf("failed to delete secret '%s': %v", secret.UUID, err)
 					printFailed("Error trying to delete secret:")
@@ -132,9 +132,7 @@ func downloadEncryptedSecrets(fingerprint fp.Fingerprint, secretLister listSecre
 func decryptSecrets(encryptedSecrets []v1structs.Secret, privateKey *pgpkey.PgpKey) (
 	secrets []secret, secretErrors []error) {
 	for _, encryptedSecret := range encryptedSecrets {
-		secret := secret{
-			sentToFingerprint: privateKey.Fingerprint(),
-		}
+		secret := secret{}
 		err := decryptAPISecret(encryptedSecret, &secret, privateKey)
 		if err != nil {
 			secretErrors = append(secretErrors, err)
@@ -212,9 +210,8 @@ const (
 )
 
 type secret struct {
-	decryptedContent  string
-	UUID              uuid.UUID
-	sentToFingerprint fingerprint.Fingerprint
+	decryptedContent string
+	UUID             uuid.UUID
 }
 
 type errListSecrets struct {

--- a/fk/secretreceive_test.go
+++ b/fk/secretreceive_test.go
@@ -104,9 +104,7 @@ func TestDecryptAPISecret(t *testing.T) {
 				EncryptedContent:  "",
 			}
 			mockPrivateKey := &mockDecryptor{}
-			decryptedSecret := secret{}
-
-			err := decryptAPISecret(encryptedSecret, &decryptedSecret, mockPrivateKey)
+			_, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
 			assert.Equal(t, fmt.Errorf("encryptedSecret.EncryptedContent can not be empty"), err)
 		})
 
@@ -116,21 +114,8 @@ func TestDecryptAPISecret(t *testing.T) {
 				EncryptedContent:  "fake encrypted content",
 			}
 			mockPrivateKey := &mockDecryptor{}
-			decryptedSecret := secret{}
-
-			err := decryptAPISecret(encryptedSecret, &decryptedSecret, mockPrivateKey)
+			_, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
 			assert.Equal(t, fmt.Errorf("encryptedSecret.EncryptedMetadata can not be empty"), err)
-		})
-
-		t.Run("rejects nil decrypted secret", func(t *testing.T) {
-			encryptedSecret := v1structs.Secret{
-				EncryptedMetadata: "fake encrypted metadata",
-				EncryptedContent:  "fake encrypted content",
-			}
-			mockPrivateKey := &mockDecryptor{}
-
-			err := decryptAPISecret(encryptedSecret, nil, mockPrivateKey)
-			assert.Equal(t, fmt.Errorf("decryptedSecret can not be nil"), err)
 		})
 
 		t.Run("rejects nil private key", func(t *testing.T) {
@@ -138,9 +123,7 @@ func TestDecryptAPISecret(t *testing.T) {
 				EncryptedMetadata: "fake encrypted metadata",
 				EncryptedContent:  "fake encrypted content",
 			}
-			decryptedSecret := secret{}
-
-			err := decryptAPISecret(encryptedSecret, &decryptedSecret, nil)
+			_, err := decryptAPISecret(encryptedSecret, nil)
 			assert.Equal(t, fmt.Errorf("privateKey can not be nil"), err)
 		})
 	})
@@ -149,14 +132,13 @@ func TestDecryptAPISecret(t *testing.T) {
 		EncryptedMetadata: "fake encrypted metadata",
 		EncryptedContent:  "fake encrypted content",
 	}
-	decryptedSecret := secret{}
 
 	t.Run("passes up errors when decrypting content", func(t *testing.T) {
 		mockPrivateKey := &mockDecryptor{
 			decryptedArmoredToStringError: fmt.Errorf("fake error decrypting content"),
 		}
 
-		err := decryptAPISecret(encryptedSecret, &decryptedSecret, mockPrivateKey)
+		_, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
 		assert.Equal(t, fmt.Errorf("error decrypting secret: "+
 			"fake error decrypting content"), err)
 	})
@@ -165,9 +147,7 @@ func TestDecryptAPISecret(t *testing.T) {
 		mockPrivateKey := &mockDecryptor{
 			decryptedArmoredError: fmt.Errorf("fake error decrypting metadata"),
 		}
-		decryptedSecret := secret{}
-
-		err := decryptAPISecret(encryptedSecret, &decryptedSecret, mockPrivateKey)
+		_, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
 		expectedErr := fmt.Errorf("error decrypting secret metadata: " +
 			"fake error decrypting metadata")
 		assert.Equal(t, expectedErr, err)
@@ -177,9 +157,7 @@ func TestDecryptAPISecret(t *testing.T) {
 		mockPrivateKey := &mockDecryptor{
 			decryptedArmoredResult: strings.NewReader("invalid json"),
 		}
-		decryptedSecret := secret{}
-
-		err := decryptAPISecret(encryptedSecret, &decryptedSecret, mockPrivateKey)
+		_, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
 		assert.ErrorIsNotNil(t, err)
 		expectedErr := fmt.Errorf("error decoding secret metadata: " +
 			"invalid character 'i' looking for beginning of value")
@@ -190,9 +168,7 @@ func TestDecryptAPISecret(t *testing.T) {
 		mockPrivateKey := &mockDecryptor{
 			decryptedArmoredResult: strings.NewReader(`{"secretUuid": "invalid uuid"}`),
 		}
-		decryptedSecret := secret{}
-
-		err := decryptAPISecret(encryptedSecret, &decryptedSecret, mockPrivateKey)
+		_, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
 		assert.ErrorIsNotNil(t, err)
 		expectedErr := fmt.Errorf("error decoding secret metadata: " +
 			"uuid: incorrect UUID length: invalid uuid")
@@ -206,9 +182,7 @@ func TestDecryptAPISecret(t *testing.T) {
 			),
 			decryptedArmoredToStringResult: "decrypted content",
 		}
-		decryptedSecret := secret{}
-
-		err := decryptAPISecret(encryptedSecret, &decryptedSecret, mockPrivateKey)
+		decryptedSecret, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
 		assert.ErrorIsNil(t, err)
 
 		t.Run("with decrypted content", func(t *testing.T) {


### PR DESCRIPTION
* refactor (back) decryptAPISecret: return secret

  since we no longer use sentToFingerprint, the pattern of passing in a
  half-populated `secret` doesn't make sense any more. Just return it from
  decryptAPISecret.