### PR TITLE
check file isn't binary and doesn't contain bad runes *before* previewing it to send

### DIFF
--- a/fk/secretsend.go
+++ b/fk/secretsend.go
@@ -126,6 +126,13 @@ func getSecretFromFile(filename string, fileReader ioutilReadFileInterface, prom
 	if len(strings.TrimSpace(secret)) == 0 {
 		return "", fmt.Errorf(filename + " is empty")
 	}
+	if !utf8.ValidString(secret) {
+		return "", fmt.Errorf(filename + " is not valid utf8 (is it a binary?)")
+	}
+	if stringutils.ContainsDisallowedRune(secret) {
+		return "", fmt.Errorf(filename + " contained disallowed characters")
+	}
+
 	out.Print("---\n")
 	out.Print(secret)
 	out.Print("---\n\n")

--- a/fk/secretsend_test.go
+++ b/fk/secretsend_test.go
@@ -109,6 +109,28 @@ func TestGetSecretFromFile(t *testing.T) {
 		assert.Equal(t, expectedErr, err)
 	})
 
+	t.Run("returns error if file is binary", func(t *testing.T) {
+		fileReader := mockReadFile{
+			readFileError: nil,
+			readFileBytes: []byte{255},
+		}
+
+		_, err := getSecretFromFile("/fake/filename", fileReader, nil)
+		expectedErr := fmt.Errorf("/fake/filename is not valid utf8 (is it a binary?)")
+		assert.Equal(t, expectedErr, err)
+	})
+
+	t.Run("returns error if file contains invalid runes", func(t *testing.T) {
+		fileReader := mockReadFile{
+			readFileError: nil,
+			readFileBytes: []byte("\x1b[31m Red \007 Bell"),
+		}
+
+		_, err := getSecretFromFile("/fake/filename", fileReader, nil)
+		expectedErr := fmt.Errorf("/fake/filename contained disallowed characters")
+		assert.Equal(t, expectedErr, err)
+	})
+
 	t.Run("returns error if user answers no", func(t *testing.T) {
 
 		fileReader := mockReadFile{


### PR DESCRIPTION
I think it's worth doing it here *and* if the user goes on to confirm
they want to send the file at prompt, as in theory they could
maliciously overwrite the file after the first check.