### PR TITLE
validate secret *before* previewing to screen

### DIFF
--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -40,7 +40,6 @@ import (
 	"github.com/fluidkeys/fluidkeys/humanize"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
-	"github.com/fluidkeys/fluidkeys/stringutils"
 	"github.com/gofrs/uuid"
 )
 
@@ -223,7 +222,7 @@ func decryptAPISecret(
 		return nil, fmt.Errorf("got binary data, expected text")
 	}
 
-	if stringutils.ContainsDisallowedRune(decryptedContent) {
+	if !isValidTextSecret(decryptedContent) {
 		return nil, fmt.Errorf("secret contained invalid characters")
 	}
 

--- a/fk/secretreceive_test.go
+++ b/fk/secretreceive_test.go
@@ -260,6 +260,19 @@ func TestDecryptAPISecret(t *testing.T) {
 			assert.Equal(t, fmt.Errorf("got binary data, expected text"), err)
 		})
 
+		t.Run("error if it isn't valid utf-8", func(t *testing.T) {
+			mockPrivateKey := &mockDecryptor{
+				decryptedArmoredResult: strings.NewReader(
+					`{"secretUuid": "93d5ac5b-74e5-4f87-b117-b8d7576395d8"}`,
+				),
+				decryptedArmoredToStringResult:      string([]byte{255}),
+				decryptedArmoredToStringLiteralData: &packet.LiteralData{},
+			}
+
+			_, err := decryptAPISecret(encryptedSecret, mockPrivateKey)
+
+			assert.Equal(t, fmt.Errorf("secret contained invalid characters"), err)
+		})
 		t.Run("error if it contains disallowed runes", func(t *testing.T) {
 			mockPrivateKey := &mockDecryptor{
 				decryptedArmoredResult: strings.NewReader(

--- a/fk/secretsend.go
+++ b/fk/secretsend.go
@@ -83,7 +83,7 @@ https://download.fluidkeys.com#` + recipientEmail + `
 		secret, err = getSecretFromFile(filename, nil, nil)
 		basename = filepath.Base(filename)
 	} else {
-		secret, err = getSecretFromStdin()
+		secret, err = getSecretFromStdin(&stdinReader{})
 		basename = ""
 	}
 	if err != nil {
@@ -137,12 +137,12 @@ func getSecretFromFile(filename string, fileReader ioutilReadFileInterface, prom
 	return secret, nil
 }
 
-func getSecretFromStdin() (string, error) {
+func getSecretFromStdin(scanner scanUntilEOFInterface) (string, error) {
 	out.Print("\n")
 	out.Print(colour.Info(femaleSpyEmoji + "  Type or paste your message, ending by typing Ctrl-D\n"))
 	out.Print(colour.Info("   It will be end-to-end encrypted so no-one else can read it\n\n"))
 
-	secret, err := scanUntilEOF()
+	secret, err := scanner.scanUntilEOF()
 	if err != nil {
 		log.Panic(err)
 		return "", err
@@ -155,7 +155,10 @@ func getSecretFromStdin() (string, error) {
 	return secret, nil
 }
 
-func scanUntilEOF() (message string, err error) {
+
+type stdinReader struct{}
+
+func (s *stdinReader) scanUntilEOF() (message string, err error) {
 	reader := bufio.NewReader(os.Stdin)
 	var output []rune
 
@@ -217,6 +220,10 @@ func makeFileHintsForFilename(filename string) *openpgp.FileHints {
 		fileHints.FileName = filename
 	}
 	return &fileHints
+}
+
+type scanUntilEOFInterface interface {
+	scanUntilEOF() (message string, err error)
 }
 
 type ioutilReadFileInterface interface {


### PR DESCRIPTION
* add all-new tests for getSecretFromStdin
  convert scanUntilEOF -> stdinReader.scanUntilEOF(), adding a scanUntilEOFInterface for mocking

* also use new isValidTextSecret from secret receive to be consistent across both and send receive