### PR TITLE
secret send: limit input size to 10K

### DIFF
--- a/fk/secretsend.go
+++ b/fk/secretsend.go
@@ -259,12 +259,13 @@ func readUpTo(source io.Reader, maxBytes int64) ([]byte, error) {
 	bytesRead, err := io.CopyN(buf, source, maxBytes+1)
 	switch err {
 	case io.EOF:
-		// case 1
-		// we should *always* hit io.EOF: the source should run out before we hit maxBytes
+		// case 1 or 2
+		// we should *always* hit io.EOF: the source should run out before maxBytes+1
 		return buf.Bytes()[:bytesRead], nil
 
 	case nil:
-		// we didn't hit EOF, so CopyN must have reached maxBytes
+		// we didn't hit EOF, so CopyN must have reached maxBytes+1, ie there was too
+		// much data
 		return nil, errTooMuchData
 
 	default:

--- a/fk/secretsend_test.go
+++ b/fk/secretsend_test.go
@@ -151,6 +151,29 @@ func TestGetSecretFromFile(t *testing.T) {
 
 }
 
+func TestReadUpTo(t *testing.T) {
+	t.Run("input 4 bytes, maxLength 5 should return 4 bytes", func(t *testing.T) {
+		input := []byte("1234")
+		gotBytes, gotErr := readUpTo(bytes.NewBuffer(input), 5)
+		assert.ErrorIsNil(t, gotErr)
+		assert.Equal(t, input, gotBytes)
+	})
+
+	t.Run("input 5 bytes, maxLength 5 should return 5 bytes", func(t *testing.T) {
+		input := []byte("12345")
+		gotBytes, gotErr := readUpTo(bytes.NewBuffer(input), 5)
+		assert.ErrorIsNil(t, gotErr)
+		assert.Equal(t, input, gotBytes)
+	})
+
+	t.Run("input 6 bytes, maxLength 5 should return error: too much data", func(t *testing.T) {
+		input := []byte("123456")
+		_, gotErr := readUpTo(bytes.NewBuffer(input), 5)
+		assert.Equal(t, gotErr, errTooMuchData)
+	})
+
+}
+
 func TestGetSecretFromStdin(t *testing.T) {
 	t.Run("returns stdin content with nil error for valid message", func(t *testing.T) {
 		stdinScanner := &mockScanStdin{

--- a/fk/secretsend_test.go
+++ b/fk/secretsend_test.go
@@ -54,7 +54,7 @@ type mockReadFile struct {
 	readFileError error
 }
 
-func (m mockReadFile) ReadFile(filename string) ([]byte, error) {
+func (m mockReadFile) ReadFileMaxBytes(filename string, maxBytes int64) ([]byte, error) {
 	return m.readFileBytes, m.readFileError
 }
 


### PR DESCRIPTION
add a new `readUpTo` function which returns []byte from an `io.Reader` but only up to `maxBytes`.

Use this new `readUpTo` in both getSecretFromStdin and getSecretFromFile