### PR TITLE
deduplicate case-identical email addresses

### DIFF
--- a/pgpkey/pgpkey_test.go
+++ b/pgpkey/pgpkey_test.go
@@ -161,6 +161,61 @@ func TestEmailsMethod(t *testing.T) {
 
 		assert.AssertEqualSliceOfStrings(t, expected, got)
 	})
+
+	t.Run("deduplicateEmails", func(t *testing.T) {
+		t.Run("deduplicates identical emails", func(t *testing.T) {
+			emails := []string{
+				"john@example.com",
+				"john@example.com",
+			}
+			expected := []string{
+				"john@example.com",
+			}
+
+			assert.Equal(t, expected, deduplicateEmails(emails))
+		})
+
+		t.Run("deduplicates case variants, choosing first occurrence", func(t *testing.T) {
+			emails := []string{
+				"John@example.com",
+				"john@example.com",
+			}
+			expected := []string{"John@example.com"}
+
+			assert.Equal(t, expected, deduplicateEmails(emails))
+
+			emails = []string{
+				"john@example.com",
+				"John@example.com",
+			}
+			expected = []string{"john@example.com"}
+
+			assert.Equal(t, expected, deduplicateEmails(emails))
+		})
+
+		t.Run("deduplicates example with multiple addresses", func(t *testing.T) {
+			emails := []string{
+				"a@example.com",
+				"a@example.com",
+				"a@EXAMPLE.com",
+				"A@example.com",
+				"A@example.com",
+
+				"B@example.com",
+				"B@example.com",
+				"b@example.com",
+				"b@example.com",
+				"b@EXAMPLE.com",
+			}
+
+			expected := []string{
+				"a@example.com",
+				"B@example.com",
+			}
+
+			assert.Equal(t, expected, deduplicateEmails(emails))
+		})
+	})
 }
 
 func TestFingerprintMethod(t *testing.T) {


### PR DESCRIPTION
* deduplicate actually identical emails. fixes
  https://trello.com/c/nLFjEDGH/552-fluidkeys-doesnt-de-duplicate-emails-addresses-properly

* deduplicate case-identical email addresses
  e.g. a@example.com, A@example.com
  even though the spec says that case does matter (for the part before
  the @), in practice very few (if any?) mail hosts actually
  differentiate. Fixes
  https://trello.com/c/w1pEwccy/662-dont-send-separate-emails-to-different-emails-if-the-only-difference-is-uppercase-lowercase

That said, if a key has John@example.com and john@example.com *and*
John@example.com is marked as primary, we'll retain that one of the two
(because we preserve order, and primary emails are sorted before
non-primary ones)