### PR TITLE
Truncate long secrets

### DIFF
--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -197,8 +197,15 @@ func decryptSecrets(encryptedSecrets []v1structs.Secret, privateKey *pgpkey.PgpK
 func formatSecretListItem(decryptedContent string, filename string) (output string) {
 	noLogDividerLength := FileDividerLength - utf8.RuneCountInString(out.NoLogCharacter)
 	output = out.NoLogCharacter + formatFileDivider(filename, noLogDividerLength) + "\n"
-	output = output + decryptedContent
-	output = output + formatFileDivider("", FileDividerLength) + "\n\n"
+	truncatedPreivew, wasTruncated := formatFirstTwentyLines(decryptedContent)
+	output = output + truncatedPreivew
+	if wasTruncated {
+		output = output +
+			formatFileDivider("[ preview limited to 20 lines ]", FileDividerLength) + "\n\n"
+	} else {
+		output = output +
+			formatFileDivider("", FileDividerLength) + "\n\n"
+	}
 	return output
 }
 

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	homedir "github.com/mitchellh/go-homedir"
 
@@ -194,16 +195,10 @@ func decryptSecrets(encryptedSecrets []v1structs.Secret, privateKey *pgpkey.PgpK
 }
 
 func formatSecretListItem(decryptedContent string, filename string) (output string) {
-	trimmedDivider := strings.Repeat(secretDividerRune, secretDividerLength-(1))
-	output = out.NoLogCharacter + trimmedDivider + "\n"
-	if filename != "" {
-		output = output + colour.File("Filename: "+filename) + "\n"
-	}
+	noLogDividerLength := FileDividerLength - utf8.RuneCountInString(out.NoLogCharacter)
+	output = out.NoLogCharacter + formatFileDivider(filename, noLogDividerLength) + "\n"
 	output = output + decryptedContent
-	if !strings.HasSuffix(decryptedContent, "\n") {
-		output = output + "\n"
-	}
-	output = output + strings.Repeat(secretDividerRune, secretDividerLength) + "\n"
+	output = output + formatFileDivider("", FileDividerLength) + "\n\n"
 	return output
 }
 
@@ -366,11 +361,6 @@ func splitFileExtension(basename string) (string, string) {
 
 	return strings.TrimSuffix(basename, extension), extension
 }
-
-const (
-	secretDividerRune   = "─"
-	secretDividerLength = 30
-)
 
 type secret struct {
 	decryptedContent string

--- a/fk/secretsend.go
+++ b/fk/secretsend.go
@@ -83,9 +83,15 @@ https://download.fluidkeys.com#` + recipientEmail + `
 
 		basename = filepath.Base(filename)
 
-		out.Print(formatFileDivider(basename) + "\n")
-		out.Print(secret)
-		out.Print(formatFileDivider("") + "\n")
+		truncatedPreview, wasTruncated := formatFirstTwentyLines(secret)
+
+		out.Print(formatFileDivider(basename, FileDividerLength) + "\n")
+		out.Print(truncatedPreview)
+		if wasTruncated {
+			out.Print(formatFileDivider("[ preview limited to 20 lines ]", FileDividerLength) + "\n")
+		} else {
+			out.Print(formatFileDivider("", FileDividerLength) + "\n")
+		}
 		out.Print("\n")
 
 		out.Print(colour.Info("The file will be end-to-end encrypted to ") + recipientEmail + "\n")

--- a/fk/ui.go
+++ b/fk/ui.go
@@ -78,6 +78,25 @@ func formatFileDivider(filename string) string {
 	return leftDecoration + colour.File(filename) + rightDecoration
 }
 
+// formatFirstTwentyLines takes an input string and returns the first 20 lines of it plus a boolean
+// of whether it was truncated.
+// The return string always ends with a trailing new line `\n`: i.e. if input was `line 1\nline2`,
+// it returns `line 1\nline\n`
+func formatFirstTwentyLines(input string) (string, bool) {
+	lines := strings.SplitN(input, "\n", 21)
+	if len(lines) == 21 && lines[20] != "" {
+		return strings.Join(lines[0:20], "\n") + "\n", true
+	}
+	return appendNewlineIfMissing(input), false
+}
+
+func appendNewlineIfMissing(input string) string {
+	if input[len(input)-1:] == "\n" {
+		return input
+	}
+	return input + "\n"
+}
+
 const (
 	fileDividerRune      = "─"
 	fileDividerMinRepeat = 2

--- a/fk/ui.go
+++ b/fk/ui.go
@@ -55,12 +55,19 @@ func printHeader(message string) {
 	out.Print(colour.Header(fmt.Sprintf(" %-79s", message)) + "\n\n")
 }
 
-// formatFileDivider takes a message, and returns it 'decorated' with lines either side.
-// i.e. `end of file` -> `── end of file ─────────────────────────────────────────`
-// If no message is provided, it returns a single, unbroken line.
-func formatFileDivider(message string) string {
+// formatFileDivider takes a message, and returns it 'decorated' with lines either side, to a
+// length of dividerLength.
+// i.e.   `end of file`
+//  ->    `── end of file ────────`
+// If the given message is longer than the divider length, it is truncated,
+// i.e.   `end of a long message`
+//  ->    `── end of a long me… ──`
+// If no message is provided, it returns a single, unbroken line of length dividerLength.
+func formatFileDivider(message string, dividerLength int) string {
+	maxMessageLength := calculateMaxMessageLength(dividerLength)
+
 	if message == "" {
-		return strings.Repeat(fileDividerRune, fileDividerLength)
+		return strings.Repeat(fileDividerRune, dividerLength)
 	}
 
 	if utf8.RuneCountInString(message) > maxMessageLength {
@@ -77,7 +84,7 @@ func formatFileDivider(message string) string {
 
 	rightDecoration := " " + strings.Repeat(
 		fileDividerRune,
-		fileDividerLength-(utf8.RuneCountInString(leftDecoration+message)+1),
+		dividerLength-(utf8.RuneCountInString(leftDecoration+message)+1),
 	)
 
 	return leftDecoration + colour.File(message) + rightDecoration
@@ -105,9 +112,10 @@ func appendNewlineIfMissing(input string) string {
 const (
 	fileDividerRune      = "─"
 	fileDividerMinRepeat = 2
-	fileDividerLength    = 80
 )
 
-var (
-	maxMessageLength = fileDividerLength - (2 * (fileDividerMinRepeat + 1))
-)
+const FileDividerLength = 80
+
+func calculateMaxMessageLength(dividerLength int) int {
+	return dividerLength - (2 * (fileDividerMinRepeat + 1))
+}

--- a/fk/ui.go
+++ b/fk/ui.go
@@ -55,27 +55,32 @@ func printHeader(message string) {
 	out.Print(colour.Header(fmt.Sprintf(" %-79s", message)) + "\n\n")
 }
 
-// formatFileDivider returns a divider string, including a filename if given, e.g.:
-// ── readme.txt ──────────────────────────────────────────────────
-func formatFileDivider(filename string) string {
-	if filename == "" {
+// formatFileDivider takes a message, and returns it 'decorated' with lines either side.
+// i.e. `end of file` -> `── end of file ─────────────────────────────────────────`
+// If no message is provided, it returns a single, unbroken line.
+func formatFileDivider(message string) string {
+	if message == "" {
 		return strings.Repeat(fileDividerRune, fileDividerLength)
 	}
 
-	if utf8.RuneCountInString(filename) > maxFilenameLength {
-		extension := filepath.Ext(filename)
-		remainingCharacters := maxFilenameLength - (utf8.RuneCountInString(extension) + 1) // '…'
-		filename = filename[:remainingCharacters] + "…" + extension
+	if utf8.RuneCountInString(message) > maxMessageLength {
+		extension := filepath.Ext(message)
+		if extension == "" {
+			message = message[:(maxMessageLength-1)] + "…"
+		} else {
+			remainingCharacters := maxMessageLength - (utf8.RuneCountInString(extension) + 1) // '…'
+			message = message[:remainingCharacters] + "…" + extension
+		}
 	}
 
 	leftDecoration := strings.Repeat(fileDividerRune, fileDividerMinRepeat) + " "
 
 	rightDecoration := " " + strings.Repeat(
 		fileDividerRune,
-		fileDividerLength-(utf8.RuneCountInString(leftDecoration+filename)+1),
+		fileDividerLength-(utf8.RuneCountInString(leftDecoration+message)+1),
 	)
 
-	return leftDecoration + colour.File(filename) + rightDecoration
+	return leftDecoration + colour.File(message) + rightDecoration
 }
 
 // formatFirstTwentyLines takes an input string and returns the first 20 lines of it plus a boolean
@@ -104,5 +109,5 @@ const (
 )
 
 var (
-	maxFilenameLength = fileDividerLength - (2 * (fileDividerMinRepeat + 1))
+	maxMessageLength = fileDividerLength - (2 * (fileDividerMinRepeat + 1))
 )

--- a/fk/ui_test.go
+++ b/fk/ui_test.go
@@ -54,9 +54,9 @@ func TestFormatFileDivider(t *testing.T) {
 			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 		})
 
-		t.Run("filename is 1 less than maxFilenameLength", func(t *testing.T) {
+		t.Run("filename is 1 less than maxMessageLength", func(t *testing.T) {
 			// should not be truncated
-			filename := strings.Repeat("a", maxFilenameLength-1)
+			filename := strings.Repeat("a", maxMessageLength-1)
 			divider := formatFileDivider(filename)
 
 			assert.Equal(
@@ -67,9 +67,9 @@ func TestFormatFileDivider(t *testing.T) {
 			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 		})
 
-		t.Run("filename is exactly maxFilenameLength", func(t *testing.T) {
+		t.Run("filename is exactly maxMessageLength", func(t *testing.T) {
 			// should not be truncated
-			filename := strings.Repeat("a", maxFilenameLength)
+			filename := strings.Repeat("a", maxMessageLength)
 			divider := formatFileDivider(filename)
 
 			assert.Equal(
@@ -80,25 +80,25 @@ func TestFormatFileDivider(t *testing.T) {
 			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 		})
 
-		t.Run("filename is 1 more than maxFilenameLength", func(t *testing.T) {
-			filename := strings.Repeat("a", maxFilenameLength+1)
+		t.Run("filename is 1 more than maxMessageLength", func(t *testing.T) {
+			filename := strings.Repeat("a", maxMessageLength+1)
 			divider := formatFileDivider(filename)
 
 			assert.Equal(
 				t,
-				"── "+colour.File(filename[0:maxFilenameLength-1]+"…")+" ──",
+				"── "+colour.File(filename[0:maxMessageLength-1]+"…")+" ──",
 				divider,
 			)
 			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 		})
 
-		t.Run("filename is 100 more than maxFilenameLength", func(t *testing.T) {
-			filename := strings.Repeat("a", maxFilenameLength+100)
+		t.Run("filename is 100 more than maxMessageLength", func(t *testing.T) {
+			filename := strings.Repeat("a", maxMessageLength+100)
 			divider := formatFileDivider(filename)
 
 			assert.Equal(
 				t,
-				"── "+colour.File(filename[0:maxFilenameLength-1]+"…")+" ──",
+				"── "+colour.File(filename[0:maxMessageLength-1]+"…")+" ──",
 				divider,
 			)
 			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))

--- a/fk/ui_test.go
+++ b/fk/ui_test.go
@@ -13,95 +13,92 @@ import (
 
 func TestFormatFileDivider(t *testing.T) {
 	t.Run("with no filename provided", func(t *testing.T) {
-		divider := formatFileDivider("")
+		divider := formatFileDivider("", 20)
 		assert.Equal(
 			t,
-			"────────────────────────────────────────────────────────────────────────────────",
+			"────────────────────",
 			divider,
 		)
-		assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
+		assert.Equal(t, 20, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 	})
 
 	t.Run("with a short filename provided", func(t *testing.T) {
-		divider := formatFileDivider("example.txt")
+		divider := formatFileDivider("example.txt", 20)
 		assert.Equal(
 			t,
-			"── "+colour.File("example.txt")+
-				" ─────────────────────────────────────────────────────────────────",
+			"── "+colour.File("example.txt")+" ─────",
 			divider,
 		)
-		assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
+		assert.Equal(t, 20, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 	})
 
 	t.Run("with a long filename provided", func(t *testing.T) {
-		divider := formatFileDivider("example1234567890123456789012345678901234567890123456789012345678901234567890.txt")
+		divider := formatFileDivider("example1234567890.txt", 20)
 		assert.Equal(
 			t,
-			"── "+
-				colour.File("example12345678901234567890123456789012345678901234567890123456789012….txt")+
-				" ──",
+			"── "+colour.File("example12….txt")+" ──",
 			divider,
 		)
-		assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
+		assert.Equal(t, 20, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 
 		t.Run("with no file extension", func(t *testing.T) {
-			divider := formatFileDivider("example1234567890123456789012345678901234567890123456789012345678901234567890")
+			divider := formatFileDivider("example1234567890", 20)
 			assert.Equal(
 				t,
-				"── "+colour.File("example123456789012345678901234567890123456789012345678901234567890123456…")+" ──",
+				"── "+colour.File("example123456…")+" ──",
 				divider,
 			)
-			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
+			assert.Equal(t, 20, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 		})
 
 		t.Run("filename is 1 less than maxMessageLength", func(t *testing.T) {
 			// should not be truncated
-			filename := strings.Repeat("a", maxMessageLength-1)
-			divider := formatFileDivider(filename)
+			filename := strings.Repeat("a", calculateMaxMessageLength(20-1))
+			divider := formatFileDivider(filename, 20)
 
 			assert.Equal(
 				t,
 				"── "+colour.File(filename)+" ───", // note: 3 runes on right
 				divider,
 			)
-			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
+			assert.Equal(t, 20, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 		})
 
 		t.Run("filename is exactly maxMessageLength", func(t *testing.T) {
 			// should not be truncated
-			filename := strings.Repeat("a", maxMessageLength)
-			divider := formatFileDivider(filename)
+			filename := strings.Repeat("a", calculateMaxMessageLength(20))
+			divider := formatFileDivider(filename, 20)
 
 			assert.Equal(
 				t,
 				"── "+colour.File(filename)+" ──",
 				divider,
 			)
-			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
+			assert.Equal(t, 20, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 		})
 
 		t.Run("filename is 1 more than maxMessageLength", func(t *testing.T) {
-			filename := strings.Repeat("a", maxMessageLength+1)
-			divider := formatFileDivider(filename)
+			filename := strings.Repeat("a", calculateMaxMessageLength(20+1))
+			divider := formatFileDivider(filename, 20)
 
 			assert.Equal(
 				t,
-				"── "+colour.File(filename[0:maxMessageLength-1]+"…")+" ──",
+				"── "+colour.File(filename[0:calculateMaxMessageLength(20-1)]+"…")+" ──",
 				divider,
 			)
-			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
+			assert.Equal(t, 20, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 		})
 
 		t.Run("filename is 100 more than maxMessageLength", func(t *testing.T) {
-			filename := strings.Repeat("a", maxMessageLength+100)
-			divider := formatFileDivider(filename)
+			filename := strings.Repeat("a", calculateMaxMessageLength(20+100))
+			divider := formatFileDivider(filename, 20)
 
 			assert.Equal(
 				t,
-				"── "+colour.File(filename[0:maxMessageLength-1]+"…")+" ──",
+				"── "+colour.File(filename[0:calculateMaxMessageLength(20-1)]+"…")+" ──",
 				divider,
 			)
-			assert.Equal(t, 80, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
+			assert.Equal(t, 20, utf8.RuneCountInString(colour.StripAllColourCodes(divider)))
 		})
 	})
 


### PR DESCRIPTION
### Introduce formatFirstTwentyLines

`formatFirstTwentyLines` takes an input string and returns the first 20 lines of it plus a boolean of whether it was truncated.

The return string always ends with a trailing new line `\n`: i.e. if input was `line 1\nline2`, it returns `line 1\nline\n`

### Use `formatFirstTwentyLines` to truncate secrets when sending and receiving

When receiving a secret, the preview looks like this:

![screenshot 2019-02-12 at 10 37 13](https://user-images.githubusercontent.com/55195/52629817-83b14500-2eb2-11e9-9055-7a559021d39a.png)

### Make `formatFileDivider` take a length

We'd been hardcoding `fileDividerLength` as 80, but since we want to use `formatFileDivider` for previewing secrets, we need to prepend the divider with the no log character. Doing so would make the line > 80 runes long!

By taking a variable we can now account for this.

### Make `formatFileDivider` take a message, not a filename**
FormatFileDivider now wants to take a more generic message (i.e. "this preview shows only 20 lines")