### PR TITLE
check for cron-output flag at highest level

### DIFF
--- a/fk/keymaintain.go
+++ b/fk/keymaintain.go
@@ -34,7 +34,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/status"
 )
 
-func keyMaintain(dryRun bool, automatic bool, cronOutput bool) exitCode {
+func keyMaintain(dryRun bool, automatic bool) exitCode {
 	keys, err := loadPgpKeys()
 	if err != nil {
 		log.Panic(err)
@@ -54,14 +54,7 @@ func keyMaintain(dryRun bool, automatic bool, cronOutput bool) exitCode {
 			passwordPrompter = &interactivePasswordPrompter{}
 		}
 
-		if cronOutput {
-			out.SetOutputToBuffer()
-		}
-		exitCode := runKeyMaintain(keys, yesNoPrompter, passwordPrompter)
-		if exitCode != 0 {
-			out.PrintTheBuffer()
-		}
-		return exitCode
+		return runKeyMaintain(keys, yesNoPrompter, passwordPrompter)
 	}
 }
 

--- a/fk/main.go
+++ b/fk/main.go
@@ -207,11 +207,7 @@ func keySubcommand(args docopt.Opts) exitCode {
 		if err != nil {
 			log.Panic(err)
 		}
-		cronOutput, err := args.Bool("--cron-output")
-		if err != nil {
-			log.Panic(err)
-		}
-		os.Exit(keyMaintain(dryRun, automatic, cronOutput))
+		os.Exit(keyMaintain(dryRun, automatic))
 	case "upload":
 		os.Exit(keyUpload())
 	}

--- a/fk/main.go
+++ b/fk/main.go
@@ -193,11 +193,14 @@ func keySubcommand(args docopt.Opts) exitCode {
 	}) {
 	case "create":
 		exitCode, _ := keyCreate("")
-		os.Exit(exitCode)
+		return exitCode
+
 	case "from-gpg":
-		os.Exit(keyFromGpg())
+		return keyFromGpg()
+
 	case "list":
-		os.Exit(keyList())
+		return keyList()
+
 	case "maintain":
 		dryRun, err := args.Bool("--dry-run")
 		if err != nil {
@@ -207,9 +210,10 @@ func keySubcommand(args docopt.Opts) exitCode {
 		if err != nil {
 			log.Panic(err)
 		}
-		os.Exit(keyMaintain(dryRun, automatic))
+		return keyMaintain(dryRun, automatic)
+
 	case "upload":
-		os.Exit(keyUpload())
+		return keyUpload()
 	}
 	log.Panicf("keySubcommand got unexpected arguments: %v", args)
 	panic(nil)

--- a/fk/main.go
+++ b/fk/main.go
@@ -89,17 +89,21 @@ Options:
 
 	ensureCrontabStateMatchesConfig()
 
+	var code exitCode
+
 	switch getSubcommand(args, []string{"key", "secret", "setup"}) {
 	case "key":
-		return keySubcommand(args)
+		code = keySubcommand(args)
 	case "secret":
-		return secretSubcommand(args)
+		code = secretSubcommand(args)
 	case "setup":
-		return setupSubcommand(args)
+		code = setupSubcommand(args)
 	default:
 		out.Print("unhandled subcommand")
-		return 1
+		code = 1
 	}
+
+	return code
 }
 
 func ensureCrontabStateMatchesConfig() {


### PR DESCRIPTION
rather than down in the key maintain subcommand

we're doing this because we're about to introduce a 2nd occurrence of the
flag and it doesn't make sense to implement twice