### PR TITLE
add MVP `fk team sync` with team roster file

### DIFF
--- a/fk/main.go
+++ b/fk/main.go
@@ -64,6 +64,7 @@ Configuration file: %s
 
 Usage:
 	fk setup
+	fk team sync
 	fk setup <email>
 	fk secret send <recipient-email>
 	fk secret send [<filename>] --to=<email>
@@ -99,7 +100,7 @@ Options:
 	}
 	var code exitCode
 
-	switch getSubcommand(args, []string{"key", "secret", "setup"}) {
+	switch getSubcommand(args, []string{"key", "secret", "setup", "team"}) {
 	case "key":
 		code = keySubcommand(args)
 
@@ -109,6 +110,8 @@ Options:
 	case "setup":
 		code = setupSubcommand(args)
 
+	case "team":
+		code = teamSubcommand(args)
 	default:
 		out.Print("unhandled subcommand")
 		code = 1
@@ -138,7 +141,8 @@ func ensureCrontabStateMatchesConfig() {
 		}
 
 		if crontabWasAdded {
-			printInfo(fmt.Sprintf("Added Fluidkeys to crontab.  Edit %s to remove.", Config.GetFilename()))
+			printInfo(fmt.Sprintf("Added Fluidkeys to crontab.  Edit %s to remove.",
+				Config.GetFilename()))
 		}
 	} else {
 		crontabWasRemoved, err := scheduler.Disable()

--- a/fk/team.go
+++ b/fk/team.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package fk
+
+import (
+	"log"
+
+	"github.com/docopt/docopt-go"
+)
+
+func teamSubcommand(args docopt.Opts) exitCode {
+	switch getSubcommand(args, []string{
+		"sync",
+	}) {
+
+	case "sync":
+		return teamSync()
+	}
+	log.Panicf("secretSubcommand got unexpected arguments: %v", args)
+	panic(nil)
+}

--- a/fk/teamsync.go
+++ b/fk/teamsync.go
@@ -1,0 +1,98 @@
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package fk
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/fluidkeys/fluidkeys/api"
+	"github.com/fluidkeys/fluidkeys/colour"
+	fp "github.com/fluidkeys/fluidkeys/fingerprint"
+	"github.com/fluidkeys/fluidkeys/humanize"
+	"github.com/fluidkeys/fluidkeys/out"
+	"github.com/fluidkeys/fluidkeys/teamroster"
+)
+
+func teamSync() exitCode {
+	teams, err := teamroster.Load(fluidkeysDirectory)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	var sawError = false
+
+	for _, team := range teams {
+		out.Print("\n")
+		out.Print(colour.Info(team.Name) + "\n")
+		out.Print("\n")
+
+		out.Print("Fetching keys and importing into gpg:\n\n")
+
+		for email, person := range team.People {
+			if person.Fingerprint == nil {
+				printFailedAction("no fingerprint for " + email)
+				sawError = true
+				continue
+			}
+
+			err := getAndImportKeyToGpg(*person.Fingerprint)
+			if err != nil {
+				printFailedAction("Failed: " + err.Error())
+				sawError = true
+				continue
+			}
+
+			printSuccessfulAction(email)
+		}
+	}
+
+	if sawError {
+		out.Print("\n")
+		printFailed("Encountered errors while syncing :(\n")
+		return 1
+	}
+	out.Print("\n")
+	printSuccess("Fetched keys for " + humanize.Pluralize(len(teams), "team", "teams") + ".")
+	return 0
+}
+
+func getAndImportKeyToGpg(fingerprint fp.Fingerprint) error {
+	key, err := client.GetPublicKeyByFingerprint(fingerprint)
+
+	if err != nil && err == api.ErrPublicKeyNotFound {
+		log.Print(err)
+		return fmt.Errorf("Couldn't find key")
+	} else if err != nil {
+		log.Print(err)
+		return fmt.Errorf("Got error from Fluidkeys server")
+	}
+
+	armoredKey, err := key.Armor()
+	if err != nil {
+		log.Print(err)
+		return fmt.Errorf("failed to ASCII armor key")
+	}
+
+	err = gpg.ImportArmoredKey(armoredKey)
+	if err != nil {
+		log.Print(err)
+		return fmt.Errorf("Failed to import key into gpg")
+	}
+	return nil
+}

--- a/teamroster/teamroster.go
+++ b/teamroster/teamroster.go
@@ -1,0 +1,122 @@
+package teamroster
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/fluidkeys/fluidkeys/fingerprint"
+	"github.com/gofrs/uuid"
+)
+
+// Load scans the fluidkeys/teams directory for subdirectories, enters them and tries to load
+// roster.toml
+// Returns a slice of Team
+func Load(fluidkeysDirectory string) ([]Team, error) {
+	teamRosters, err := findTeamRosters(filepath.Join(fluidkeysDirectory, "teams"))
+	if err != nil {
+		return nil, err
+	}
+
+	teams := []Team{}
+	for _, teamRoster := range teamRosters {
+		log.Printf("loading team roster %s\n", teamRoster)
+		team, err := loadTeamRoster(teamRoster)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load %s: %v", teamRoster, err)
+		}
+		teams = append(teams, *team)
+	}
+	return teams, nil
+}
+
+func findTeamRosters(directory string) ([]string, error) {
+	teamSubdirs, err := ioutil.ReadDir(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	teamRosters := []string{}
+
+	for _, teamSubDir := range teamSubdirs {
+		if !teamSubDir.IsDir() {
+			continue
+		}
+
+		teamRoster := filepath.Join(directory, teamSubDir.Name(), "roster.toml")
+		// TODO: also look for teamRoster.asc and validate the signature
+
+		if fileExists(teamRoster) {
+			teamRosters = append(teamRosters, teamRoster)
+		} else {
+			log.Printf("missing %s", teamRoster)
+		}
+	}
+	return teamRosters, nil
+}
+
+func loadTeamRoster(filename string) (*Team, error) {
+	reader, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %v", filename, err)
+	}
+
+	team, err := parse(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return team, nil
+}
+
+func parse(r io.Reader) (*Team, error) {
+	var parsedTeam Team
+	metadata, err := toml.DecodeReader(r, &parsedTeam)
+
+	if err != nil {
+		return nil, fmt.Errorf("error in toml.DecodeReader: %v", err)
+	}
+
+	if len(metadata.Undecoded()) > 0 {
+		// found config variables that we don't know how to match to
+		// the Team structure
+		return nil, fmt.Errorf("encountered unrecognised config keys: %v", metadata.Undecoded())
+	}
+
+	return &parsedTeam, nil
+
+}
+
+func fileExists(filename string) bool {
+	if fileinfo, err := os.Stat(filename); err == nil {
+		// path/to/whatever exists
+		return !fileinfo.IsDir()
+	}
+	return false
+}
+
+type Team struct {
+	UUID   uuid.UUID         `toml:uuid`
+	Name   string            `toml:name`
+	People map[string]Person `toml:people`
+}
+
+func (t *Team) Fingerprints() []fingerprint.Fingerprint {
+	fps := []fingerprint.Fingerprint{}
+
+	for _, person := range t.People {
+
+		if person.Fingerprint != nil {
+			fps = append(fps, *person.Fingerprint)
+		}
+	}
+	return fps
+}
+
+type Person struct {
+	Fingerprint *fingerprint.Fingerprint
+}


### PR DESCRIPTION
the roster lives in `~/.config/fluidkeys/teams/<whatever>/team.toml` and
looks like this:

``` uuid = "38be2a70-23d8-11e9-bafd-7f97f2e239a3" name = "Fluidkeys CIC"

[people]
 [people."paul@fluidkeys.com"]
 fingerprint = "B79F 0840 DEF1 2EBB A72F  F72D 7327 A44C 2157 A758"

  [people."ian@fluidkeys.com"]
 fingerprint = "E63A F0E7 4EB5 DE3F B72D  C981 C991 7093 18EC BDE7"
```

Note that we will cryptographically validate `roster.asc` before release.