### PR TITLE
add `make test_lint` to run `gometalinter`

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,39 @@
+{
+    "Enable": [
+	"vet",
+	"deadcode",
+	"dupl",
+	"errcheck",
+	"gochecknoglobals",
+	"goconst",
+	"gocyclo",
+	"goimports",
+	"golint",
+	"gosec",
+	"gotype",
+	"gotypex",
+	"ineffassign",
+	"interfacer",
+	"lll",
+	"maligned",
+	"nakedret",
+	"staticcheck",
+	"structcheck",
+	"unconvert",
+	"unparam",
+	"varcheck"
+    ],
+    "Disable": [
+	"safesql",
+	"gochecknoinits",
+	"misspell",
+	"unparam",
+	"dupl",
+	"gochecknoglobals",
+	"lll"
+    ],
+    "VendoredLinters": true,
+    "Skip": [
+	"vendor"
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ test:
 	./script/test_dep_gopkg_files
 	./script/test_discover_dbus_session_address
 
+.PHONY: test_lint
+test_lint:
+	gometalinter --config .gometalinter.json ./...
+
 .PHONY: run
 run: $(MAIN_GO_FILES)
 	go run $<


### PR DESCRIPTION
so we can manually run it with repeatable configuration (even though the
tests don't currently depend on it)

this should get all the dependencies if you're feeling brave:

```
go get -u github.com/zmb3/gogetdoc
go get -u github.com/davidrjenni/reftools/cmd/fillstruct
go get -u github.com/rogpeppe/godef
go get -u github.com/fatih/motion
go get -u github.com/kisielk/errcheck
go get -u github.com/derekparker/delve/cmd/dlv
go get -u github.com/mdempsky/gocode
go get -u github.com/josharian/impl
go get -u github.com/koron/iferr
go get -u github.com/jstemmer/gotags
go get -u github.com/stamblerre/gocode
go get -u github.com/fatih/gomodifytags
go get -u github.com/klauspost/asmfmt/cmd/asmfmt
go get -u github.com/alecthomas/gometalinter
go get -u golang.org/x/tools/cmd/gotype
go get -u github.com/mdempsky/maligned
go get -u github.com/mvdan/interfacer
go get -u github.com/tsenart/deadcode
go get -u golang.org/x/tools/cmd/gotype
go get -u honnef.co/go/tools/cmd/staticcheck
go get -u github.com/opennota/check
go get -u github.com/alecthomas/gocyclo
go get -u github.com/opennota/check
go get -u github.com/jgautheron/goconst/cmd/goconst
go get -u github.com/securego/gosec/cmd/gosec
go get -u github.com/gordonklaus/ineffassign
go get -u github.com/mdempsky/unconvert
go get -u gitlab.com/opennota/check/cmd/structcheck
go get -u gitlab.com/opennota/check/cmd/varcheck
go get -u mvdan.cc/interfacer
go get -u mvdan.cc/unparam
go get -u github.com/alexkohler/nakedret
```