### PR TITLE
stop passing time into gpg.BackupHomeDir

### DIFF
--- a/fk/keymaintain.go
+++ b/fk/keymaintain.go
@@ -379,7 +379,7 @@ func makeGnupgBackup(now time.Time) (string, error) {
 		return "", err
 	}
 
-	filename, err := gpg.BackupHomeDir(filepath, now)
+	filename, err := gpg.BackupHomeDir(filepath)
 	if err != nil {
 		return "", fmt.Errorf("failed to call gpg.BackupHomeDir: %v", err)
 	}

--- a/gpgwrapper/backup.go
+++ b/gpgwrapper/backup.go
@@ -22,6 +22,8 @@ import (
 	"os/exec"
 )
 
+// BackupHomeDir makes a .tar backup file of the user's GnuPG directory
+// to the given filepath
 func (g *GnuPG) BackupHomeDir(filepath string) (string, error) {
 	cmd := "tar"
 	gpgHomeDir, err := g.HomeDir()

--- a/gpgwrapper/backup.go
+++ b/gpgwrapper/backup.go
@@ -20,10 +20,9 @@ package gpgwrapper
 import (
 	"fmt"
 	"os/exec"
-	"time"
 )
 
-func (g *GnuPG) BackupHomeDir(filepath string, now time.Time) (string, error) {
+func (g *GnuPG) BackupHomeDir(filepath string) (string, error) {
 	cmd := "tar"
 	gpgHomeDir, err := g.HomeDir()
 	if err != nil {

--- a/gpgwrapper/backup_test.go
+++ b/gpgwrapper/backup_test.go
@@ -5,11 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 func TestBackupHomeDir(t *testing.T) {
-	now := time.Date(2018, 6, 15, 0, 0, 0, 0, time.UTC)
 	tmpDirectory, err := ioutil.TempDir("", "fluidkeys")
 	tmpFilePath := filepath.Join(tmpDirectory, "example.tgz")
 	if err != nil {
@@ -17,7 +15,7 @@ func TestBackupHomeDir(t *testing.T) {
 	}
 	gpg := makeGpgWithTempHome(t)
 
-	filename, _ := gpg.BackupHomeDir(tmpFilePath, now)
+	filename, _ := gpg.BackupHomeDir(tmpFilePath)
 
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		t.Fatalf("Expected %v to exist, but it doesn't", filename)


### PR DESCRIPTION
This code is a hangover from when we used to timestamp the file backup. We don't do this anymore since we put the file in a timestamped directory (as seen in `makeGnupgBackup`).

Comment `gpgwrapper.Backuphomedir` to make this clear.