### PR TITLE
Show pending action before trying to edit crontab

### DIFF
--- a/fk/keycreate.go
+++ b/fk/keycreate.go
@@ -161,10 +161,10 @@ func keyCreate(email string) (exitCode, *pgpkey.PgpKey) {
 
 	out.Print("🛠️  Carrying out the following tasks:\n\n")
 
-	printSuccessfulAction("Generate key for " + email)
+	printCheckboxSuccess("Generate key for " + email)
 
 	if err = pushPrivateKeyBackToGpg(generateJob.pgpKey, password.AsString(), &gpg); err == nil {
-		printSuccessfulAction("Store key in gpg")
+		printCheckboxSuccess("Store key in gpg")
 	} else {
 		log.Panicf("error pushing key back to gpg: %v", err)
 	}
@@ -175,21 +175,21 @@ func keyCreate(email string) (exitCode, *pgpkey.PgpKey) {
 	}
 
 	if err := tryEnableMaintainAutomatically(generateJob.pgpKey, password.AsString()); err == nil {
-		printSuccessfulAction("Store password in " + Keyring.Name())
-		printSuccessfulAction("Automatically rotate key each month using cron")
+		printCheckboxSuccess("Store password in " + Keyring.Name())
+		printCheckboxSuccess("Automatically rotate key each month using cron")
 	} else {
-		printFailedAction("Setup automatic maintenance")
+		printCheckboxFailure("Automatically rotate key each month using cron", err)
 	}
 
 	filename, err := backupzip.OutputZipBackupFile(fluidkeysDirectory, generateJob.pgpKey, password.AsString())
 	if err != nil {
-		printFailedAction("Make a backup ZIP file")
+		printCheckboxFailure("Make a backup ZIP file", err)
 	}
 	directory, _ := filepath.Split(filename)
-	printSuccessfulAction("Make a backup ZIP file in")
+	printCheckboxSuccess("Make a backup ZIP file in")
 	out.Print("        " + directory + "\n")
 
-	printSuccessfulAction("Register " + email + " so others can send you secrets")
+	printCheckboxSuccess("Register " + email + " so others can send you secrets")
 	out.Print("\n")
 
 	printSuccess("Successfully created key and registered " + email)

--- a/fk/keycreate.go
+++ b/fk/keycreate.go
@@ -174,8 +174,17 @@ func keyCreate(email string) (exitCode, *pgpkey.PgpKey) {
 		log.Panicf("failed to record fingerprint imported into gpg: %v", err)
 	}
 
-	if err := tryEnableMaintainAutomatically(generateJob.pgpKey, password.AsString()); err == nil {
+	printCheckboxPending("Store password in " + Keyring.Name())
+
+	if err := tryStorePassword(generateJob.pgpKey.Fingerprint(), password.AsString()); err == nil {
 		printCheckboxSuccess("Store password in " + Keyring.Name())
+	} else {
+		printCheckboxFailure("Store password in "+Keyring.Name(), err)
+	}
+
+	printCheckboxPending("Automatically rotate key each month using cron")
+
+	if err := tryMaintainAutomatically(generateJob.pgpKey.Fingerprint()); err == nil {
 		printCheckboxSuccess("Automatically rotate key each month using cron")
 	} else {
 		printCheckboxFailure("Automatically rotate key each month using cron", err)

--- a/fk/keymaintain.go
+++ b/fk/keymaintain.go
@@ -400,7 +400,7 @@ func printCheckboxSkipped(actionText string) {
 }
 
 func printCheckboxFailure(actionText string, err error) {
-	out.Print(fmt.Sprintf("     %s %s\n", colour.Error("[!]"), actionText))
+	out.Print(fmt.Sprintf("     [%s] %s\n", colour.Error("✗"), actionText))
 	out.Print(fmt.Sprintf("         %s\n", colour.Error(fmt.Sprintf("%s", err))))
 }
 

--- a/fk/teamsync.go
+++ b/fk/teamsync.go
@@ -46,19 +46,19 @@ func teamSync() exitCode {
 
 		for email, person := range team.People {
 			if person.Fingerprint == nil {
-				printFailedAction("no fingerprint for " + email)
+				printCheckboxSkipped("no fingerprint for " + email)
 				sawError = true
 				continue
 			}
 
 			err := getAndImportKeyToGpg(*person.Fingerprint)
 			if err != nil {
-				printFailedAction("Failed: " + err.Error())
+				printCheckboxFailure("Fail to fetch key", err)
 				sawError = true
 				continue
 			}
 
-			printSuccessfulAction(email)
+			printCheckboxSuccess(email)
 		}
 	}
 

--- a/fk/ui.go
+++ b/fk/ui.go
@@ -43,14 +43,6 @@ func printWarning(message string) {
 	out.Print(" " + colour.Warning("▸   "+message) + "\n")
 }
 
-func printSuccessfulAction(message string) {
-	out.Print("    [" + colour.Success("✔") + "] " + message + "\n")
-}
-
-func printFailedAction(message string) {
-	out.Print("    [" + colour.Failure("✘") + "] " + message + "\n")
-}
-
 func printHeader(message string) {
 	out.Print(colour.Header(fmt.Sprintf(" %-79s", message)) + "\n\n")
 }


### PR DESCRIPTION
This allows us to handle the checkboxes independently, and print a pending
action while asking for permission for terminal to modify the users
crontab.

Split tryEnableMaintainAutomatically > tryStorePassword & tryMaintainAutomatically