### PR TITLE
team setup: prompt for team name and members

### DIFF
--- a/fk/main.go
+++ b/fk/main.go
@@ -66,6 +66,7 @@ Configuration file: %s
 Usage:
 	fk setup
 	fk setup <email>
+	fk team setup
 	fk team sync [--cron-output]
 	fk secret send <recipient-email>
 	fk secret send [<filename>] --to=<email>
@@ -101,7 +102,7 @@ Options:
 	}
 	var code exitCode
 
-	switch getSubcommand(args, []string{"key", "secret", "setup", "team"}) {
+	switch getSubcommand(args, []string{"key", "secret", "team", "setup"}) {
 	case "key":
 		code = keySubcommand(args)
 

--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -17,22 +17,6 @@
 
 package fk
 
-import (
-	"log"
-
-	"github.com/docopt/docopt-go"
-)
-
-func teamSubcommand(args docopt.Opts) exitCode {
-	switch getSubcommand(args, []string{
-		"sync", "setup",
-	}) {
-
-	case "sync":
-		return teamSync()
-	case "setup":
-		return teamCreate()
-	}
-	log.Panicf("secretSubcommand got unexpected arguments: %v", args)
-	panic(nil)
+func teamCreate() exitCode {
+	return 0
 }

--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -17,6 +17,80 @@
 
 package fk
 
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/fluidkeys/fluidkeys/emailutils"
+	"github.com/fluidkeys/fluidkeys/out"
+	"github.com/fluidkeys/fluidkeys/stringutils"
+	"github.com/fluidkeys/fluidkeys/ui"
+)
+
 func teamCreate() exitCode {
-	return 0
+	out.Print("\n")
+
+	out.Print("A Team is a group of people using Fluidkeys together.\n\n")
+	out.Print("Fluidkeys automates configuration and key exchange for the team.\n\n")
+	out.Print("This makes it easy to send secrets to one another and use other popular\n")
+	out.Print("PGP tools.\n\n")
+
+	printHeader("What's your team name?")
+
+	out.Print("This is how your team will be displayed to you and other members. You can\n")
+	out.Print("always change this later.\n\n")
+
+	var teamName string
+	var err error
+
+	for teamName == "" {
+		teamName, err = validateTeamName(promptForInput("[team name] : "))
+		if err != nil {
+			printWarning(err.Error())
+		}
+	}
+
+	printHeader("Who would you like to invite into " + teamName + "?")
+
+	out.Print("One by one, add the emails of the people you'd like to invite to join.\n")
+	out.Print("You can always invite others later.\n\n")
+	out.Print("Finish by entering a blank address\n\n")
+
+	var teamMemberEmails []string
+
+	for {
+		memberEmail := promptForInput("[email] : ")
+		if memberEmail == "" {
+			break
+		}
+		if !emailutils.RoughlyValidateEmail(memberEmail) {
+			printWarning("Not a valid email address")
+			continue
+		}
+		teamMemberEmails = append(teamMemberEmails, memberEmail)
+	}
+
+	printHeader("Finishing setup")
+
+	out.Print("You've indicated you want to invite the following members to " +
+		teamName + ":\n\n")
+	for _, memberEmail := range teamMemberEmails {
+		out.Print(memberEmail + "\n")
+	}
+
+	out.Print(ui.FormatWarning("Teams are not currently implemented", []string{
+		"This feature is coming soon.",
+	}, nil))
+
+	return 1
+}
+
+func validateTeamName(teamName string) (string, error) {
+	if teamName == "" {
+		return "", fmt.Errorf("Team name was blank")
+	}
+	if !utf8.ValidString(teamName) || stringutils.ContainsDisallowedRune(teamName) {
+		return "", fmt.Errorf("Team name contained invalid characters")
+	}
+	return teamName, nil
 }

--- a/fk/teamcreate_test.go
+++ b/fk/teamcreate_test.go
@@ -1,0 +1,44 @@
+package fk
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fluidkeys/fluidkeys/colour"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+)
+
+func TestValidateTeamName(t *testing.T) {
+	t.Run("returns the name as a string if valid", func(t *testing.T) {
+		teamName := "Kiffix"
+
+		got, err := validateTeamName(teamName)
+		assert.ErrorIsNil(t, err)
+		assert.Equal(t, teamName, got)
+	})
+
+	t.Run("returns an empty string and error if blank", func(t *testing.T) {
+		teamName := ""
+
+		got, err := validateTeamName(teamName)
+		assert.Equal(t, "", got)
+		assert.Equal(t, fmt.Errorf("Team name was blank"), err)
+	})
+
+	t.Run("returns an empty string and error if contains disallowed runes", func(t *testing.T) {
+		teamName := colour.Warning("Kiffix")
+
+		got, err := validateTeamName(teamName)
+		assert.Equal(t, "", got)
+		assert.Equal(t, fmt.Errorf("Team name contained invalid characters"), err)
+	})
+
+	t.Run("returns an empty string and error if not valid utf-8", func(t *testing.T) {
+		teamName := string([]byte{255})
+
+		got, err := validateTeamName(teamName)
+		assert.Equal(t, "", got)
+		assert.Equal(t, fmt.Errorf("Team name contained invalid characters"), err)
+	})
+}


### PR DESCRIPTION
This command doesn't actually do anything with the information it collects
at this stage. It just prints it back to screen and warns the user that
this feature isn't currently implemented.