### PR TITLE
move `team setup` to `team create`

### DIFF
--- a/fk/main.go
+++ b/fk/main.go
@@ -66,7 +66,7 @@ Configuration file: %s
 Usage:
 	fk setup
 	fk setup <email>
-	fk team setup
+	fk team create
 	fk team sync [--cron-output]
 	fk secret send <recipient-email>
 	fk secret send [<filename>] --to=<email>

--- a/fk/team.go
+++ b/fk/team.go
@@ -25,12 +25,12 @@ import (
 
 func teamSubcommand(args docopt.Opts) exitCode {
 	switch getSubcommand(args, []string{
-		"sync", "setup",
+		"sync", "create",
 	}) {
 
 	case "sync":
 		return teamSync()
-	case "setup":
+	case "create":
 		return teamCreate()
 	}
 	log.Panicf("secretSubcommand got unexpected arguments: %v", args)


### PR DESCRIPTION
`setup` is a reserved command in Fluidkeys. It's a "wizard" that
guides the user through getting started with Fluidkeys.

We `create` other objects: keys, teams, ...