### PR TITLE
add TOML annotations to teamroster.People

### DIFF
--- a/teamroster/teamroster.go
+++ b/teamroster/teamroster.go
@@ -119,6 +119,6 @@ func (t *Team) Fingerprints() []fingerprint.Fingerprint {
 
 // Person represents a human team member
 type Person struct {
-	Email       string
-	Fingerprint fingerprint.Fingerprint
+	Email       string                  `toml:"email"`
+	Fingerprint fingerprint.Fingerprint `toml:"fingerprint"`
 }


### PR DESCRIPTION
so the toml files comes out as `email` not `Email`