### PR TITLE
Team create: Save the team as `roster.toml` to disk

### DIFF
--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/fluidkeys/fluidkeys/stringutils"
+	"github.com/fluidkeys/fluidkeys/team"
 	"github.com/fluidkeys/fluidkeys/ui"
 )
 
@@ -76,6 +77,14 @@ func teamCreate() exitCode {
 		colour.Cmd("fk key create") + "\n")
 	out.Print("\n")
 	key := promptForTeamEmail(keys)
+
+	email, err := key.Email()
+	if err != nil {
+		out.Print(ui.FormatFailure("Couldn't get email address for key", nil, err))
+		return 1
+	}
+
+	teamMembers := []team.Person{{Email: email, Fingerprint: key.Fingerprint()}}
 
 	printHeader("What's your team name?")
 
@@ -129,6 +138,10 @@ func teamCreate() exitCode {
 			printCheckboxSkipped(fmt.Sprintf("%s\nmultiple keys found: skipping", teamMemberEmail))
 
 		case len(publicKeyListings) == 1:
+			teamMembers = append(teamMembers, team.Person{
+				Email:       teamMemberEmail,
+				Fingerprint: publicKeyListings[0].Fingerprint,
+			})
 			printCheckboxSuccess(
 				fmt.Sprintf("%s\n%*sfound key %s", teamMemberEmail, 9, " ",
 					publicKeyListings[0].Fingerprint))

--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -19,6 +19,7 @@ package fk
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"unicode/utf8"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/stringutils"
 	"github.com/fluidkeys/fluidkeys/team"
 	"github.com/fluidkeys/fluidkeys/ui"
+	"github.com/gofrs/uuid"
 )
 
 func teamCreate() exitCode {
@@ -152,8 +154,25 @@ func teamCreate() exitCode {
 
 	printHeader("Finishing setup")
 
-	out.Print("You've indicated you want setup " + teamName + " using your key\n")
-	out.Print(fmt.Sprintf("%s\n", key.Fingerprint()))
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		out.Print(ui.FormatFailure("Error creating UUID for team", nil, err))
+		return 1
+	}
+
+	t := team.Team{
+		UUID:   uuid,
+		Name:   teamName,
+		People: teamMembers,
+	}
+
+	printCheckboxPending("Create team roster")
+	err = team.Save(t, fluidkeysDirectory)
+	if err != nil {
+		printCheckboxFailure("Create team roster", err)
+	}
+	printCheckboxSuccess("Create team roster in \n" +
+		filepath.Join(fluidkeysDirectory, "teams"))
 
 	out.Print(ui.FormatWarning("Teams are not currently implemented", []string{
 		"This feature is coming soon.",

--- a/team/roster.go
+++ b/team/roster.go
@@ -25,3 +25,18 @@ func Parse(r io.Reader) (*Team, error) {
 	return &parsedTeam, nil
 
 }
+
+func (t *Team) serialize(w io.Writer) error {
+	err := t.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid team: %v", err)
+	}
+	if _, err := io.WriteString(w, defaultRosterFile); err != nil {
+		return err
+	}
+	encoder := toml.NewEncoder(w)
+	return encoder.Encode(t)
+}
+
+const defaultRosterFile = `# Fluidkeys team roster
+`

--- a/team/roster_test.go
+++ b/team/roster_test.go
@@ -1,8 +1,11 @@
 package team
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/fluidkeys/fluidkeys/exampledata"
 
 	"github.com/fluidkeys/fluidkeys/assert"
 	"github.com/fluidkeys/fluidkeys/fingerprint"
@@ -28,6 +31,59 @@ func TestParse(t *testing.T) {
 
 	assert.Equal(t, uuid.Must(uuid.FromString("38be2a70-23d8-11e9-bafd-7f97f2e239a3")), team.UUID)
 	assert.Equal(t, "Fluidkeys CIC", team.Name)
+}
+
+func TestSerialize(t *testing.T) {
+	t.Run("for a valid team", func(t *testing.T) {
+		testTeam := Team{
+			Name: "Kiffix",
+			UUID: uuid.Must(uuid.FromString("6caa3730-2ca3-47b9-b671-5dc326100431")),
+			People: []Person{
+				Person{
+					Email:       "test2@example.com",
+					Fingerprint: exampledata.ExampleFingerprint2,
+				},
+				Person{
+					Email:       "test3@example.com",
+					Fingerprint: exampledata.ExampleFingerprint3,
+				},
+			},
+		}
+
+		output := bytes.NewBuffer(nil)
+		err := testTeam.serialize(output)
+		assert.ErrorIsNil(t, err)
+
+		expected := `# Fluidkeys team roster
+uuid = "6caa3730-2ca3-47b9-b671-5dc326100431"
+name = "Kiffix"
+
+[[person]]
+  email = "test2@example.com"
+  fingerprint = "5C78E71F6FEFB55829654CC5343CC240D350C30C"
+
+[[person]]
+  email = "test3@example.com"
+  fingerprint = "7C18DE4DE47813568B243AC8719BD63EF03BDC20"
+`
+		assert.Equal(t, expected, output.String())
+	})
+
+	t.Run("for a invalid team (same person twice)", func(t *testing.T) {
+		person := Person{
+			Email:       "test2@example.com",
+			Fingerprint: exampledata.ExampleFingerprint2,
+		}
+		testTeam := Team{
+			Name:   "Kiffix",
+			UUID:   uuid.Must(uuid.FromString("6caa3730-2ca3-47b9-b671-5dc326100431")),
+			People: []Person{person, person},
+		}
+
+		output := bytes.NewBuffer(nil)
+		err := testTeam.serialize(output)
+		assert.ErrorIsNotNil(t, err)
+	})
 }
 
 const validRoster = `# Fluidkeys team roster

--- a/team/roster_test.go
+++ b/team/roster_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -84,6 +85,88 @@ name = "Kiffix"
 		err := testTeam.serialize(output)
 		assert.ErrorIsNotNil(t, err)
 	})
+}
+
+func TestSlugify(t *testing.T) {
+	var tests = []struct {
+		input    string
+		expected string
+	}{
+		{
+			"Hello world",
+			"hello-world",
+		},
+		{
+			"Marks & Spencers",
+			"marks-and-spencers",
+		},
+		{
+			"Digit@l Wizards",
+			"digital-wizards",
+		},
+		{
+			"Between [Worlds]",
+			"between-worlds",
+		},
+		{
+			"--Future--",
+			"future",
+		},
+		{
+			"😁 Happy Cleaners 💦",
+			"happy-cleaners",
+		},
+		{
+			"déjà vu",
+			"d-j-vu",
+		},
+		{
+			"\n\000\037 \041\176\177\200\377\n",
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("slugifying `%s`", test.input), func(t *testing.T) {
+			assert.Equal(t, test.expected, slugify(test.input))
+		})
+	}
+}
+
+func TestSubDirectory(t *testing.T) {
+	var tests = []struct {
+		team     Team
+		expected string
+	}{
+		{
+			Team{
+				Name: "kiffix",
+				UUID: uuid.Must(uuid.FromString("6caa3730-2ca3-47b9-b671-5dc326100431")),
+			},
+			"kiffix-6caa3730-2ca3-47b9-b671-5dc326100431",
+		},
+		{
+			Team{
+				Name: "😁 Happy Cleaners 💦",
+				UUID: uuid.Must(uuid.FromString("6caa3730-2ca3-47b9-b671-5dc326100431")),
+			},
+			"happy-cleaners-6caa3730-2ca3-47b9-b671-5dc326100431",
+		},
+		{
+			Team{
+				Name: "😁",
+				UUID: uuid.Must(uuid.FromString("6caa3730-2ca3-47b9-b671-5dc326100431")),
+			},
+			"6caa3730-2ca3-47b9-b671-5dc326100431",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("get directory for `%s`", test.team.Name), func(t *testing.T) {
+
+			assert.Equal(t, test.expected, test.team.subDirectory())
+		})
+	}
 }
 
 const validRoster = `# Fluidkeys team roster

--- a/team/team.go
+++ b/team/team.go
@@ -15,7 +15,7 @@ import (
 // roster.toml
 // Returns a slice of Team
 func LoadTeams(fluidkeysDirectory string) ([]Team, error) {
-	teamRosters, err := findTeamRosters(filepath.Join(fluidkeysDirectory, "teams"))
+	teamRosters, err := findTeamRosters(getTeamDirectory(fluidkeysDirectory))
 	if err != nil {
 		return nil, err
 	}
@@ -67,6 +67,10 @@ func (t *Team) GetPersonForFingerprint(fpr fingerprint.Fingerprint) (*Person, er
 	}
 
 	return nil, fmt.Errorf("person not found")
+}
+
+func getTeamDirectory(fluidkeysDirectory string) string {
+	return filepath.Join(fluidkeysDirectory, "teams")
 }
 
 func findTeamRosters(directory string) ([]string, error) {

--- a/team/team.go
+++ b/team/team.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/gofrs/uuid"
+	"github.com/natefinch/atomic"
 )
 
 // LoadTeams scans the fluidkeys/teams directory for subdirectories, enters them and tries to load
@@ -30,6 +32,37 @@ func LoadTeams(fluidkeysDirectory string) ([]Team, error) {
 		teams = append(teams, *team)
 	}
 	return teams, nil
+}
+
+// Save validates the given team then tries to create a toml team roster in a subdirectory of the
+// given directory.
+func Save(team Team, fluidkeysDirectory string) error {
+	err := team.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid team: %v", err)
+	}
+	rosterDirectory := filepath.Join(
+		getTeamDirectory(fluidkeysDirectory), // ~/.config/fluidkeys/teams
+		team.subDirectory(),                  // fluidkeys-inc-4367436743
+	)
+	if _, err := os.Stat(rosterDirectory); !os.IsNotExist(err) {
+		return fmt.Errorf("path already exists at %s", rosterDirectory)
+	}
+	if err = os.MkdirAll(rosterDirectory, 0700); err != nil {
+		return fmt.Errorf("failed to make directory %s", rosterDirectory)
+	}
+
+	roster := bytes.NewBuffer(nil)
+	if err := team.serialize(roster); err != nil {
+		return fmt.Errorf("failed to serialize team roster: %v", err)
+	}
+
+	rosterFilename := filepath.Join(rosterDirectory, "roster.toml")
+	if err = atomic.WriteFile(rosterFilename, roster); err != nil {
+		return fmt.Errorf("failed write team roster: %v", err)
+	}
+
+	return nil
 }
 
 // Validate asserts that the team roster has no email addresses or fingerprints that are


### PR DESCRIPTION
We populate the team with the original team creator and any other keys we find in `gpg`.

The file is written into a subdirectory of `.config/fluidkeys/teams` based on the name of the team and a UUID

![screenshot 2019-02-22 at 16 57 38](https://user-images.githubusercontent.com/55195/53257826-044a1f80-36c3-11e9-8b1c-694571cbac0a.png)
