### PR TITLE
Team Create: stop prompting for email addresses of team members

### DIFF
--- a/colour/colour.go
+++ b/colour/colour.go
@@ -135,6 +135,10 @@ func File(filename string) string {
 	return yellow(filename)
 }
 
+func Instruction(message string) string {
+	return bright + blue(message)
+}
+
 func underline(message string) string {
 	return underscore + message + reset
 }

--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -162,6 +162,37 @@ func teamCreate() exitCode {
 	printSuccess("Successfully created " + teamName)
 	out.Print("\n")
 
+	printHeader("Invite people to join the team")
+
+	out.Print(formatFileDivider("Invitation to join "+t.Name, 80) + "\n\n")
+
+	out.Print(`Join ` + t.Name + ` on Fluidkeys
+
+I've created a team on Fluidkeys to make it simple for us to share passwords
+and secrets securely.
+
+Join now:
+
+1. download Fluidkeys from https://download.fluidkeys.com
+
+2. join the team by running:
+
+> fk team join ` + t.UUID.String() + `
+
+`)
+	out.Print(formatFileDivider("", 80) + "\n\n")
+
+	out.Print(colour.Instruction("👆 Copy the invitation above and send it to your team.") + "\n\n")
+
+	promptForInput("Press enter to continue. ")
+
+	out.Print(ui.FormatInfo("You'll need to authorize requests to join the team with "+
+		colour.Cmd("fk team authorize"), []string{
+		"If you're already using gpg with your team, you can pre-authorise them now",
+		"by running " + colour.Cmd("fk team from-gpg"),
+	},
+	))
+
 	return 0
 }
 

--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -24,7 +24,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/fluidkeys/fluidkeys/colour"
-	"github.com/fluidkeys/fluidkeys/emailutils"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/fluidkeys/fluidkeys/stringutils"
@@ -101,56 +100,6 @@ func teamCreate() exitCode {
 			printWarning(err.Error())
 		}
 	}
-
-	printHeader("Who would you like to invite into " + teamName + "?")
-
-	out.Print("One by one, add the emails of the people you'd like to invite to join.\n")
-	out.Print("You can always invite others later.\n\n")
-	out.Print("Finish by entering a blank address\n\n")
-
-	var teamMemberEmails []string
-
-	for {
-		memberEmail := promptForInput("[email] : ")
-		if memberEmail == "" {
-			break
-		}
-		if !emailutils.RoughlyValidateEmail(memberEmail) {
-			printWarning("Not a valid email address")
-			continue
-		}
-		teamMemberEmails = append(teamMemberEmails, memberEmail)
-	}
-
-	printHeader("Searching gpg for existings keys")
-
-	for _, teamMemberEmail := range teamMemberEmails {
-		printCheckboxPending(teamMemberEmail)
-
-		publicKeyListings, err := gpg.ListPublicKeys(teamMemberEmail)
-		if err != nil {
-			printCheckboxFailure(teamMemberEmail, err)
-		}
-		switch {
-		case len(publicKeyListings) == 0:
-			printCheckboxSkipped(
-				colour.Disabled(teamMemberEmail + " no key found, you can invite them later"))
-
-		case len(publicKeyListings) > 1:
-			printCheckboxSkipped(fmt.Sprintf("%s\nmultiple keys found: skipping", teamMemberEmail))
-
-		case len(publicKeyListings) == 1:
-			teamMembers = append(teamMembers, team.Person{
-				Email:       teamMemberEmail,
-				Fingerprint: publicKeyListings[0].Fingerprint,
-			})
-			printCheckboxSuccess(
-				fmt.Sprintf("%s\n%*sfound key %s", teamMemberEmail, 9, " ",
-					publicKeyListings[0].Fingerprint))
-
-		}
-	}
-	out.Print("\n")
 
 	printHeader("Finishing setup")
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -68,6 +68,25 @@ func FormatWarning(headline string, extraLines []string, err error) string {
 	return msg
 }
 
+// FormatInfo prints a formatted info message. It should be used for useful information that you
+// want to draw to the readers attention
+func FormatInfo(headline string, extraLines []string) string {
+	msg := ""
+
+	msg += "\n"
+	msg += colour.Info("│") + " ℹ️  " + headline + "\n"
+
+	if len(extraLines) > 0 {
+		extraLines = append([]string{""}, extraLines...) // prepend a "" to extraLines
+	}
+
+	for _, line := range extraLines {
+		msg += colour.Info("│ ") + line + "\n"
+	}
+	msg += "\n"
+	return msg
+}
+
 // capitalize returns text with the first rune capitalized
 func capitalize(text string) string {
 	switch len([]rune(text)) {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -170,6 +170,47 @@ func TestFormatWarning(t *testing.T) {
 	}
 }
 
+func TestFormatInfo(t *testing.T) {
+	var tests = []struct {
+		name     string
+		input    testCase
+		expected string
+	}{
+		{
+			"with only a headline",
+			testCase{
+				headline:   "Here's some helpful info",
+				extralines: nil,
+			},
+			"\n" + colour.Info("│") + " ℹ️  Here's some helpful info\n" +
+				"\n",
+		},
+		{
+			"with a headline and two extra lines",
+			testCase{
+				headline: "Here's some helpful info",
+				extralines: []string{
+					"First extra line",
+					"Second extra line",
+				},
+				err: nil,
+			},
+			"\n" + colour.Info("│") + " ℹ️  Here's some helpful info\n" +
+				colour.Info("│ ") + "\n" +
+				colour.Info("│ ") + "First extra line\n" +
+				colour.Info("│ ") + "Second extra line\n" +
+				"\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("FormatWarning %s", test.name), func(t *testing.T) {
+			got := FormatInfo(test.input.headline, test.input.extralines)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
 func TestCapitalize(t *testing.T) {
 	var tests = []struct {
 		input    string


### PR DESCRIPTION
Instead, provide the admin with an invitation they can copy and paste into a message to people they want to use Fluidkeys with.

We also present the admin with a preview of `roster.toml` and ask them to confirm that they want to sign it.