### PR TITLE
add unimplemented `fk team authorize`

### DIFF
--- a/fk/main.go
+++ b/fk/main.go
@@ -68,6 +68,7 @@ Usage:
 	fk setup <email>
 	fk team create
 	fk team join <uuid>
+	fk team authorize
 	fk team sync [--cron-output]
 	fk secret send <recipient-email>
 	fk secret send [<filename>] --to=<email>

--- a/fk/teamauthorize.go
+++ b/fk/teamauthorize.go
@@ -18,42 +18,11 @@
 package fk
 
 import (
-	"log"
-
-	"github.com/docopt/docopt-go"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/ui"
-	"github.com/gofrs/uuid"
 )
 
-func teamSubcommand(args docopt.Opts) exitCode {
-	switch getSubcommand(args, []string{
-		"authorize", "create", "join", "sync",
-	}) {
-
-	case "join":
-		id, err := args.String("<uuid>")
-		if err != nil {
-			log.Panic(err)
-		}
-
-		teamUUID, err := uuid.FromString(id)
-		if err != nil {
-			out.Print(ui.FormatFailure("Invalid UUID", nil, err))
-			return 1
-		}
-
-		return teamJoin(teamUUID)
-
-	case "sync":
-		return teamSync()
-
-	case "create":
-		return teamCreate()
-
-	case "authorize":
-		return teamAuthorize()
-	}
-	log.Panicf("secretSubcommand got unexpected arguments: %v", args)
-	panic(nil)
+func teamAuthorize() exitCode {
+	out.Print(ui.FormatFailure("Not implemented", nil, nil))
+	return 1
 }


### PR DESCRIPTION
Opted for authorize over authorise since ize is in the Cambridge
Dictionary where ise isn't, and a sense that American's frown
more upose ise, than brits ize.

https://www.quora.com/What-is-the-difference-between-authorise-and-authorize