### PR TITLE
factor out errSecretContainsDisallowedCharacters

### DIFF
--- a/fk/secretsend.go
+++ b/fk/secretsend.go
@@ -172,7 +172,7 @@ func getSecretFromStdin(scanner scanUntilEOFInterface) (string, error) {
 	}
 
 	if !isValidTextSecret(secret) {
-		return "", errors.New("Secret contains disallowed characters")
+		return "", errSecretContainsDisallowedCharacters
 	}
 
 	return secret, nil
@@ -289,4 +289,7 @@ func readUpTo(source io.Reader, maxBytes int64) ([]byte, error) {
 	}
 }
 
-var errTooMuchData error = errors.New("source had more data than maxBytes")
+var (
+	errTooMuchData                        = errors.New("source had more data than maxBytes")
+	errSecretContainsDisallowedCharacters = errors.New("secret contains disallowed characters")
+)

--- a/fk/secretsend_test.go
+++ b/fk/secretsend_test.go
@@ -184,7 +184,7 @@ func TestGetSecretFromStdin(t *testing.T) {
 		}
 
 		_, err := getSecretFromStdin(stdinScanner)
-		expectedErr := fmt.Errorf("Secret contains disallowed characters")
+		expectedErr := errSecretContainsDisallowedCharacters
 		assert.Equal(t, expectedErr, err)
 
 	})
@@ -195,7 +195,7 @@ func TestGetSecretFromStdin(t *testing.T) {
 		}
 
 		_, err := getSecretFromStdin(stdinScanner)
-		expectedErr := fmt.Errorf("Secret contains disallowed characters")
+		expectedErr := errSecretContainsDisallowedCharacters
 		assert.Equal(t, expectedErr, err)
 	})
 }


### PR DESCRIPTION
so we can use it in the tests to compare errors (fmt.Errorf("..") !=
errors.New("..")) in go master