### PR TITLE
assert.Equal: treat error types differently

### DIFF
--- a/assert/equality.go
+++ b/assert/equality.go
@@ -29,7 +29,12 @@ func Equal(t *testing.T, expected interface{}, got interface{}) {
 	t.Helper()
 
 	if !isEqual(expected, got) {
-		t.Fatalf("expected %v got %v", expected, got)
+		msg := fmt.Sprintf("expected `%v` got `%v`", expected, got)
+		if len(msg) < 50 {
+			t.Fatalf(msg)
+		} else {
+			t.Fatalf("\n--- expected ---\n%v\n--- got ---\n%v\n--- end ---\n", expected, got)
+		}
 	}
 }
 

--- a/assert/equality.go
+++ b/assert/equality.go
@@ -18,19 +18,32 @@
 package assert
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 )
 
-// assert.Equal aims to test equality of any two objects, and call t.Fatalf
-// if they're not equal
+// Equal aims to test equality of any two objects, and call t.Fatalf if they're not equal
 func Equal(t *testing.T, expected interface{}, got interface{}) {
 	t.Helper()
 
-	if !reflect.DeepEqual(expected, got) {
+	if !isEqual(expected, got) {
 		t.Fatalf("expected %v got %v", expected, got)
 	}
+}
+
+func isEqual(a interface{}, b interface{}) bool {
+	if aAsError, ok := a.(error); ok {
+		if bAsError, ok := b.(error); ok {
+			if reflect.TypeOf(a) != reflect.TypeOf(b) {
+				return false
+			}
+			return aAsError.Error() == bAsError.Error() // compare on error string
+		}
+	}
+
+	return reflect.DeepEqual(a, b)
 }
 
 // EqualSliceOfStrings tells whether a and b contain the same elements.

--- a/assert/error_test.go
+++ b/assert/error_test.go
@@ -1,0 +1,31 @@
+package assert
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsEqualForErrors(t *testing.T) {
+
+	t.Run("two errors made with fmt.Errorf(..) compare equal", func(t *testing.T) {
+		got := isEqual(fmt.Errorf("foo"), fmt.Errorf("foo"))
+
+		if !got {
+			t.Fatalf("expected errors to compare equal, but they didn't")
+		}
+	})
+
+	t.Run("error made with fmt.Errorf(..) equal to custom typed error", func(t *testing.T) {
+		customError := &customErrorType1{}
+		got := isEqual(fmt.Errorf("foo"), customError)
+
+		if got {
+			t.Fatalf("didn't expect errors to compare true due to different types")
+		}
+	})
+
+}
+
+type customErrorType1 struct{}
+
+func (e *customErrorType1) Error() string { return "foo" }

--- a/fk/secretsend.go
+++ b/fk/secretsend.go
@@ -172,7 +172,7 @@ func getSecretFromStdin(scanner scanUntilEOFInterface) (string, error) {
 	}
 
 	if !isValidTextSecret(secret) {
-		return "", errors.New("Secret contains disallowed characters")
+		return "", errSecretContainsDisallowedCharacters
 	}
 
 	return secret, nil
@@ -289,4 +289,7 @@ func readUpTo(source io.Reader, maxBytes int64) ([]byte, error) {
 	}
 }
 
-var errTooMuchData error = errors.New("source had more data than maxBytes")
+var (
+	errTooMuchData                        = errors.New("source had more data than maxBytes")
+	errSecretContainsDisallowedCharacters = errors.New("secret contains disallowed characters")
+)

--- a/fk/secretsend_test.go
+++ b/fk/secretsend_test.go
@@ -184,7 +184,7 @@ func TestGetSecretFromStdin(t *testing.T) {
 		}
 
 		_, err := getSecretFromStdin(stdinScanner)
-		expectedErr := fmt.Errorf("Secret contains disallowed characters")
+		expectedErr := errSecretContainsDisallowedCharacters
 		assert.Equal(t, expectedErr, err)
 
 	})
@@ -195,7 +195,7 @@ func TestGetSecretFromStdin(t *testing.T) {
 		}
 
 		_, err := getSecretFromStdin(stdinScanner)
-		expectedErr := fmt.Errorf("Secret contains disallowed characters")
+		expectedErr := errSecretContainsDisallowedCharacters
 		assert.Equal(t, expectedErr, err)
 	})
 }


### PR DESCRIPTION
if got & expected can both be cast to errors, compare them directly *as*
errors, specifically:

* if 2 errors are different type, they're not equal
* otherwise, they're equal if their strings are equal

this is motivated by a change in Go 1.13 that mean errors don't compare
equal using naive reflect.Equal

Bonus: print long errors across different lines