### PR TITLE
dont allow a pointer to fingerprint in UpsertTeam

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -162,11 +162,7 @@ func (c *Client) CreateSecret(recipientFingerprint fingerprint.Fingerprint, armo
 // UpsertTeam takes a roster, signature and fingerprint to sign the request and attempts to
 // create a secret for the given recipient
 func (c *Client) UpsertTeam(roster string, rosterSignature string,
-	signerFingerprint *fingerprint.Fingerprint) error {
-	if signerFingerprint == nil {
-		return fmt.Errorf("missing signer fingerprint")
-	}
-
+	signerFingerprint fingerprint.Fingerprint) error {
 	UpsertTeamRequest := v1structs.UpsertTeamRequest{
 		TeamRoster:               roster,
 		ArmoredDetachedSignature: rosterSignature,
@@ -175,7 +171,7 @@ func (c *Client) UpsertTeam(roster string, rosterSignature string,
 	if err != nil {
 		return err
 	}
-	request.Header.Add("authorization", authorization(*signerFingerprint))
+	request.Header.Add("authorization", authorization(signerFingerprint))
 
 	_, err = c.do(request, nil)
 	return err

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -293,21 +293,9 @@ func TestUpsertTeam(t *testing.T) {
 		err = client.UpsertTeam(
 			"# Fluidkeys team roster...",
 			"---- BEGIN PGP MESSAGE...",
-			&fingerprint,
+			fingerprint,
 		)
 		assert.NoError(t, err)
-	})
-
-	t.Run("returns error when missing the signing fingerprint", func(t *testing.T) {
-		client, _, _, teardown := setup()
-		defer teardown()
-
-		err := client.UpsertTeam(
-			"# Fluidkeys team roster...",
-			"---- BEGIN PGP MESSAGE...",
-			nil,
-		)
-		assert.Equal(t, fmt.Errorf("missing signer fingerprint"), err)
 	})
 
 	t.Run("passes up server errors", func(t *testing.T) {
@@ -325,7 +313,7 @@ func TestUpsertTeam(t *testing.T) {
 		err = client.UpsertTeam(
 			"# Fluidkeys team roster...",
 			"---- BEGIN PGP MESSAGE...",
-			&fingerprint,
+			fingerprint,
 		)
 
 		assert.Equal(t, fmt.Errorf("API error: 500 signing key not in roster"), err)

--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -115,8 +115,7 @@ func teamCreate() exitCode {
 
 	action := "Upload team roster to Fluidkeys"
 	printCheckboxPending(action)
-	signerFingerprint := privateKey.Fingerprint()
-	err = client.UpsertTeam(roster, signature, &signerFingerprint)
+	err = client.UpsertTeam(roster, signature, privateKey.Fingerprint())
 	if err != nil {
 		printCheckboxFailure(action, err)
 	}


### PR DESCRIPTION
We always raised an error if this was nil, so I think we should
force a value to be passed.