### PR TITLE
Refer to the fingerprint package as fpr and value as fingerprint

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fluidkeys/api/v1structs"
 	"github.com/fluidkeys/fluidkeys/assert"
 	"github.com/fluidkeys/fluidkeys/exampledata"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/gofrs/uuid"
 )
 
@@ -222,7 +222,7 @@ func TestCreateSecret(t *testing.T) {
 	}
 	mux.HandleFunc("/secrets", mockResponseHandler)
 
-	fingerprint, err := fingerprint.Parse("ABAB ABAB ABAB ABAB ABAB  ABAB ABAB ABAB ABAB ABAB")
+	fingerprint, err := fpr.Parse("ABAB ABAB ABAB ABAB ABAB  ABAB ABAB ABAB ABAB ABAB")
 	if err != nil {
 		t.Fatalf("Couldn't parse fingerprint: %s\n", err)
 	}
@@ -268,7 +268,7 @@ func TestUpsertTeam(t *testing.T) {
 		ArmoredDetachedSignature: "---- BEGIN PGP MESSAGE...",
 	}
 
-	fingerprint, err := fingerprint.Parse("ABAB ABAB ABAB ABAB ABAB  ABAB ABAB ABAB ABAB ABAB")
+	fingerprint, err := fpr.Parse("ABAB ABAB ABAB ABAB ABAB  ABAB ABAB ABAB ABAB ABAB")
 	if err != nil {
 		t.Fatalf("Couldn't parse fingerprint: %s\n", err)
 	}
@@ -395,7 +395,7 @@ func TestGetTeamName(t *testing.T) {
 
 func TestRequestToJoinTeam(t *testing.T) {
 	expectedRequest := &v1structs.RequestToJoinTeamRequest{TeamEmail: "jane@example.com"}
-	fingerprint, err := fingerprint.Parse("ABAB ABAB ABAB ABAB ABAB  ABAB ABAB ABAB ABAB ABAB")
+	fingerprint, err := fpr.Parse("ABAB ABAB ABAB ABAB ABAB  ABAB ABAB ABAB ABAB ABAB")
 	if err != nil {
 		t.Fatalf("Couldn't parse fingerprint: %s\n", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ import (
 	"path"
 
 	"github.com/BurntSushi/toml"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/natefinch/atomic"
 )
 
@@ -69,7 +69,7 @@ type Config struct {
 	parsedConfig   tomlConfig
 	parsedMetadata toml.MetaData
 
-	// keyConfigs map[fingerprint.Fingerprint]key
+	// keyConfigs map[fpr.Fingerprint]key
 	filename string
 }
 
@@ -95,42 +95,42 @@ func (c *Config) RunFromCron() bool {
 // be stored in the system keyring when successfully entered (avoiding future
 // password prompts).
 // The default is false.
-func (c *Config) ShouldStorePassword(fingerprint fingerprint.Fingerprint) bool {
+func (c *Config) ShouldStorePassword(fingerprint fpr.Fingerprint) bool {
 	return c.getConfig(fingerprint).StorePassword
 }
 
 // SetStorePassword sets whether the password for the given key should be
 // stored in the user's login keyring
-func (c *Config) SetStorePassword(fingerprint fingerprint.Fingerprint, value bool) error {
+func (c *Config) SetStorePassword(fingerprint fpr.Fingerprint, value bool) error {
 	return c.setProperty(fingerprint, storePassword, value)
 }
 
 // ShouldMaintainAutomatically returns whether the given key should be
 // maintained in the background. The default is false.
-func (c *Config) ShouldMaintainAutomatically(fingerprint fingerprint.Fingerprint) bool {
+func (c *Config) ShouldMaintainAutomatically(fingerprint fpr.Fingerprint) bool {
 	return c.getConfig(fingerprint).MaintainAutomatically
 }
 
 // SetMaintainAutomatically sets whether the given key should be maintained in the
 // background.
-func (c *Config) SetMaintainAutomatically(fingerprint fingerprint.Fingerprint, value bool) error {
+func (c *Config) SetMaintainAutomatically(fingerprint fpr.Fingerprint, value bool) error {
 	return c.setProperty(fingerprint, maintainAutomatically, value)
 }
 
 // ShouldPublishToAPI returns whether the given key should be uploaded to the
 // Fluidkeys directory to allow others to search for it by email address.
 // The default is false.
-func (c *Config) ShouldPublishToAPI(fingerprint fingerprint.Fingerprint) bool {
+func (c *Config) ShouldPublishToAPI(fingerprint fpr.Fingerprint) bool {
 	return c.getConfig(fingerprint).PublishToAPI
 }
 
 // SetPublishToAPI sets whether the given key should be uploaded to the
 // Fluidkeys directory to allow others to search for it by email address.
-func (c *Config) SetPublishToAPI(fingerprint fingerprint.Fingerprint, value bool) error {
+func (c *Config) SetPublishToAPI(fingerprint fpr.Fingerprint, value bool) error {
 	return c.setProperty(fingerprint, publishToAPI, value)
 }
 
-func (c *Config) setProperty(fingerprint fingerprint.Fingerprint, property keyConfigProperty, value interface{}) error {
+func (c *Config) setProperty(fingerprint fpr.Fingerprint, property keyConfigProperty, value interface{}) error {
 	if c.parsedConfig.PgpKeys == nil { // initialize the map if empty
 		c.parsedConfig.PgpKeys = make(map[string]key)
 	}
@@ -174,11 +174,11 @@ func (c *Config) save() error {
 
 // getConfig returns a `key` struct for the given Fingerprint
 // If no config is found for the fingerprint, return the default config
-func (c *Config) getConfig(fp fingerprint.Fingerprint) key {
-	keyConfigs := make(map[fingerprint.Fingerprint]key)
+func (c *Config) getConfig(fingerprint fpr.Fingerprint) key {
+	keyConfigs := make(map[fpr.Fingerprint]key)
 
 	for configFingerprint, keyConfig := range c.parsedConfig.PgpKeys {
-		parsedFingerprint, err := fingerprint.Parse(configFingerprint)
+		parsedFingerprint, err := fpr.Parse(configFingerprint)
 		if err != nil {
 			log.Panicf("got invalid openpgp fingerprint: '%s'", configFingerprint)
 		}
@@ -186,7 +186,7 @@ func (c *Config) getConfig(fp fingerprint.Fingerprint) key {
 		keyConfigs[parsedFingerprint] = keyConfig
 	}
 
-	if keyConfig, inMap := keyConfigs[fp]; inMap {
+	if keyConfig, inMap := keyConfigs[fingerprint]; inMap {
 		return keyConfig
 	} else {
 		return defaultKeyConfig()
@@ -203,7 +203,7 @@ func parse(r io.Reader) (*Config, error) {
 
 	// validate fingerprints
 	for configFingerprint, _ := range parsedConfig.PgpKeys {
-		_, err := fingerprint.Parse(configFingerprint)
+		_, err := fpr.Parse(configFingerprint)
 		if err != nil {
 			return nil, fmt.Errorf("got invalid openpgp fingerprint: '%s'", configFingerprint)
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/fluidkeys/fluidkeys/assert"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 func TestLoad(t *testing.T) {
@@ -172,7 +172,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestSerialize(t *testing.T) {
-	testFingerprint := fingerprint.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
+	testFingerprint := fpr.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
 
 	t.Run("from an empty config file", func(t *testing.T) {
 		emptyConfig, err := parse(strings.NewReader(""))
@@ -197,7 +197,7 @@ func TestSerialize(t *testing.T) {
 }
 
 func TestGetConfig(t *testing.T) {
-	fingerprint := fingerprint.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
+	fingerprint := fpr.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
 
 	t.Run("getConfig recognises 0xAAAA... fingerprint format rather than returning default config", func(t *testing.T) {
 		config, err := parse(strings.NewReader(`
@@ -226,7 +226,7 @@ func TestGetConfig(t *testing.T) {
 }
 
 func TestSettersAndGetters(t *testing.T) {
-	testFingerprint := fingerprint.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
+	testFingerprint := fpr.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
 
 	t.Run("MaintainAutomatically", func(t *testing.T) {
 		config := Config{filename: "/tmp/config.toml"}
@@ -278,7 +278,7 @@ func TestSettersAndGetters(t *testing.T) {
 }
 
 func TestShouldStorePasswordInKeyring(t *testing.T) {
-	testFingerprint := fingerprint.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
+	testFingerprint := fpr.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
 
 	t.Run("default to false for missing whole [pgpkeys] table", func(t *testing.T) {
 		config, err := parse(strings.NewReader(""))
@@ -336,7 +336,7 @@ func TestShouldStorePasswordInKeyring(t *testing.T) {
 }
 
 func TestShouldMaintainAutomaticallyInKeyring(t *testing.T) {
-	testFingerprint := fingerprint.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
+	testFingerprint := fpr.MustParse("AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111")
 
 	t.Run("default to false for missing whole [pgpkeys] table", func(t *testing.T) {
 		config, err := parse(strings.NewReader(""))

--- a/database/database.go
+++ b/database/database.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 type Database struct {
@@ -44,7 +44,7 @@ func New(fluidkeysDirectory string) Database {
 	return Database{jsonFilename: jsonFilename}
 }
 
-func (db *Database) RecordFingerprintImportedIntoGnuPG(newFingerprint fingerprint.Fingerprint) error {
+func (db *Database) RecordFingerprintImportedIntoGnuPG(newFingerprint fpr.Fingerprint) error {
 	existingFingerprints, err := db.GetFingerprintsImportedIntoGnuPG()
 	if err != nil {
 		return err
@@ -64,7 +64,7 @@ func (db *Database) RecordFingerprintImportedIntoGnuPG(newFingerprint fingerprin
 	return encoder.Encode(databaseMessage)
 }
 
-func makeDatabaseMessageFromFingerprints(fingerprints []fingerprint.Fingerprint) DatabaseMessage {
+func makeDatabaseMessageFromFingerprints(fingerprints []fpr.Fingerprint) DatabaseMessage {
 	var messages []KeyImportedIntoGnuPGMessage
 
 	for _, fingerprint := range fingerprints {
@@ -77,11 +77,11 @@ func makeDatabaseMessageFromFingerprints(fingerprints []fingerprint.Fingerprint)
 	return databaseMessage
 }
 
-func (db *Database) GetFingerprintsImportedIntoGnuPG() ([]fingerprint.Fingerprint, error) {
+func (db *Database) GetFingerprintsImportedIntoGnuPG() ([]fpr.Fingerprint, error) {
 	file, err := os.Open(db.jsonFilename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []fingerprint.Fingerprint{}, nil
+			return []fpr.Fingerprint{}, nil
 		} else {
 			return nil, fmt.Errorf("Couldn't open '%s': %v", db.jsonFilename, err)
 		}
@@ -98,11 +98,11 @@ func (db *Database) GetFingerprintsImportedIntoGnuPG() ([]fingerprint.Fingerprin
 		return nil, fmt.Errorf("error loading json: %v", err)
 	}
 
-	var fingerprints []fingerprint.Fingerprint
+	var fingerprints []fpr.Fingerprint
 
 	for _, v := range databaseMessage.KeysImportedIntoGnuPG {
 		fingerprintString := v.Fingerprint
-		parsedFingerprint, err := fingerprint.Parse(fingerprintString)
+		parsedFingerprint, err := fpr.Parse(fingerprintString)
 		if err != nil {
 			continue
 		}
@@ -112,13 +112,13 @@ func (db *Database) GetFingerprintsImportedIntoGnuPG() ([]fingerprint.Fingerprin
 	return deduplicate(fingerprints), nil
 }
 
-func deduplicate(slice []fingerprint.Fingerprint) []fingerprint.Fingerprint {
-	sliceMap := make(map[fingerprint.Fingerprint]bool)
+func deduplicate(slice []fpr.Fingerprint) []fpr.Fingerprint {
+	sliceMap := make(map[fpr.Fingerprint]bool)
 	for _, v := range slice {
 		sliceMap[v] = true
 	}
 
-	var deduped []fingerprint.Fingerprint
+	var deduped []fpr.Fingerprint
 	for key, _ := range sliceMap {
 		deduped = append(deduped, key)
 	}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/fluidkeys/fluidkeys/assert"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 func TestRecordFingerprintImportedIntoGnuPG(t *testing.T) {
@@ -68,7 +68,7 @@ func TestGetFingerprintsImportedIntoGnuPG(t *testing.T) {
 
 func TestDeduplicate(t *testing.T) {
 
-	slice := []fingerprint.Fingerprint{
+	slice := []fpr.Fingerprint{
 		exampleFingerprintA,
 		exampleFingerprintA,
 		exampleFingerprintB,
@@ -76,7 +76,7 @@ func TestDeduplicate(t *testing.T) {
 	}
 
 	got := deduplicate(slice)
-	want := []fingerprint.Fingerprint{
+	want := []fpr.Fingerprint{
 		exampleFingerprintA,
 		exampleFingerprintB,
 		exampleFingerprintC,
@@ -96,14 +96,14 @@ func makeTempDirectory(t *testing.T) string {
 	return dir
 }
 
-func assertContains(t *testing.T, slice []fingerprint.Fingerprint, element fingerprint.Fingerprint) {
+func assertContains(t *testing.T, slice []fpr.Fingerprint, element fpr.Fingerprint) {
 	t.Helper()
 	if !contains(slice, element) {
 		t.Fatalf("Expected '%v' to contain '%v'", slice, element)
 	}
 }
 
-func contains(s []fingerprint.Fingerprint, e fingerprint.Fingerprint) bool {
+func contains(s []fpr.Fingerprint, e fpr.Fingerprint) bool {
 	for _, a := range s {
 		if a == e {
 			return true
@@ -112,6 +112,6 @@ func contains(s []fingerprint.Fingerprint, e fingerprint.Fingerprint) bool {
 	return false
 }
 
-var exampleFingerprintA = fingerprint.MustParse("AAAA AAAA AAAA AAAA AAAA  AAAA AAAA AAAA AAAA AAAA")
-var exampleFingerprintB = fingerprint.MustParse("BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB")
-var exampleFingerprintC = fingerprint.MustParse("CCCC CCCC CCCC CCCC CCCC  CCCC CCCC CCCC CCCC CCCC")
+var exampleFingerprintA = fpr.MustParse("AAAA AAAA AAAA AAAA AAAA  AAAA AAAA AAAA AAAA AAAA")
+var exampleFingerprintB = fpr.MustParse("BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB")
+var exampleFingerprintC = fpr.MustParse("CCCC CCCC CCCC CCCC CCCC  CCCC CCCC CCCC CCCC CCCC")

--- a/exampledata/exampledata.go
+++ b/exampledata/exampledata.go
@@ -18,7 +18,7 @@
 package exampledata
 
 import (
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 const ExamplePublicKey2 = `
@@ -86,7 +86,7 @@ YLNqbnb5
 -----END PGP PRIVATE KEY BLOCK-----
 `
 
-var ExampleFingerprint2 = fingerprint.MustParse("5C78 E71F 6FEF B558 2965  4CC5 343C C240 D350 C30C")
+var ExampleFingerprint2 = fpr.MustParse("5C78 E71F 6FEF B558 2965  4CC5 343C C240 D350 C30C")
 
 const ExamplePublicKey3 = `
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -171,7 +171,7 @@ D/iQVXIhUGUcj8xSftV2Iw==
 -----END PGP PRIVATE KEY BLOCK-----
 `
 
-var ExampleFingerprint3 = fingerprint.MustParse("7C18 DE4D E478 1356 8B24  3AC8 719B D63E F03B DC20")
+var ExampleFingerprint3 = fpr.MustParse("7C18 DE4D E478 1356 8B24  3AC8 719B D63E F03B DC20")
 
 var ExamplePublicKey4 = `
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -238,4 +238,4 @@ TBAU6yBBSeV0Z8rL
 -----END PGP PRIVATE KEY BLOCK-----
 `
 
-var ExampleFingerprint4 = fingerprint.MustParse("BB3C 44BF 188D 56E6 35F4  A092 F73D 2F05 33D7 F9D6")
+var ExampleFingerprint4 = fpr.MustParse("BB3C 44BF 188D 56E6 35F4  A092 F73D 2F05 33D7 F9D6")

--- a/exampledata/exampledata_test.go
+++ b/exampledata/exampledata_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 
 	"github.com/fluidkeys/crypto/openpgp"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 func TestArmoredKeys(t *testing.T) {
 	var tests = []struct {
 		name                string
 		armoredKey          string
-		expectedFingerprint fingerprint.Fingerprint
+		expectedFingerprint fpr.Fingerprint
 	}{
 		{
 			`public key 2`,
@@ -51,7 +51,7 @@ func TestArmoredKeys(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s fingerprint", test.name), func(t *testing.T) {
 			entity, _ := loadKey(test.armoredKey)
-			gotFingerprint := fingerprint.FromBytes(entity.PrimaryKey.Fingerprint)
+			gotFingerprint := fpr.FromBytes(entity.PrimaryKey.Fingerprint)
 
 			if gotFingerprint != test.expectedFingerprint {
 				t.Errorf("loaded %s, expected fingerprint '%s', got '%s'", test.name, test.expectedFingerprint, gotFingerprint)

--- a/fk/keycreate.go
+++ b/fk/keycreate.go
@@ -28,7 +28,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/backupzip"
 	"github.com/fluidkeys/fluidkeys/colour"
 	"github.com/fluidkeys/fluidkeys/emailutils"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/humanize"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
@@ -246,7 +246,7 @@ type getPublicKeyInterface interface {
 }
 
 func verifyEmailMatchesKeyInAPI(
-	email string, fingerprint fingerprint.Fingerprint,
+	email string, fingerprint fpr.Fingerprint,
 	publicKeyGetter getPublicKeyInterface) (verified bool, err error) {
 
 	armoredKey, err := publicKeyGetter.GetPublicKey(email)

--- a/fk/keyfromgpg.go
+++ b/fk/keyfromgpg.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	"github.com/fluidkeys/fluidkeys/colour"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/gpgwrapper"
 	"github.com/fluidkeys/fluidkeys/humanize"
 	"github.com/fluidkeys/fluidkeys/out"
@@ -99,7 +99,7 @@ func keysAvailableToGetFromGpg() ([]gpgwrapper.KeyListing, error) {
 	}
 
 	for _, key := range allGpgKeys {
-		if !fingerprint.Contains(importedFingerprints, key.Fingerprint) {
+		if !fpr.Contains(importedFingerprints, key.Fingerprint) {
 			availableKeys = append(availableKeys, key)
 		}
 	}

--- a/fk/keymaintain.go
+++ b/fk/keymaintain.go
@@ -26,7 +26,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/archiver"
 	"github.com/fluidkeys/fluidkeys/backupzip"
 	"github.com/fluidkeys/fluidkeys/colour"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/humanize"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
@@ -452,17 +452,17 @@ func formatKeyActions(keyTask keyTask) (header string) {
 	return
 }
 
-func tryStorePassword(fpr fingerprint.Fingerprint, password string) error {
-	if err := Config.SetStorePassword(fpr, true); err != nil {
+func tryStorePassword(fingerprint fpr.Fingerprint, password string) error {
+	if err := Config.SetStorePassword(fingerprint, true); err != nil {
 		return err
 	}
-	if err := Keyring.SavePassword(fpr, password); err != nil {
+	if err := Keyring.SavePassword(fingerprint, password); err != nil {
 		return err
 	}
 	return nil
 }
 
-func tryMaintainAutomatically(fpr fingerprint.Fingerprint) error {
+func tryMaintainAutomatically(fpr fpr.Fingerprint) error {
 	if err := Config.SetMaintainAutomatically(fpr, true); err != nil {
 		return err
 	}
@@ -513,7 +513,7 @@ func (a pushIntoGnupg) String() string {
 	return "Store updated key in " + colour.Cmd("gpg")
 }
 
-type passwordMap = map[fingerprint.Fingerprint]string
+type passwordMap = map[fpr.Fingerprint]string
 
 func (a pushIntoGnupg) Enact(key *pgpkey.PgpKey, now time.Time, password *string) error {
 	if password == nil {

--- a/fk/main.go
+++ b/fk/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/status"
 
 	"github.com/fluidkeys/fluidkeys/api"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 
 	"github.com/docopt/docopt-go"
 	"github.com/fluidkeys/fluidkeys/colour"
@@ -273,7 +273,7 @@ func loadPgpKeys() ([]pgpkey.PgpKey, error) {
 	return keys, nil
 }
 
-func loadPgpKey(fingerprint fingerprint.Fingerprint) (*pgpkey.PgpKey, error) {
+func loadPgpKey(fingerprint fpr.Fingerprint) (*pgpkey.PgpKey, error) {
 	armoredPublicKey, err := gpg.ExportPublicKey(fingerprint)
 	if err != nil {
 		return nil, err

--- a/fk/main_test.go
+++ b/fk/main_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/fluidkeys/fluidkeys/colour"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/gpgwrapper"
 )
 
@@ -108,7 +108,7 @@ func TestPromptForWhichGpgKey(t *testing.T) {
 	t.Run("prints a correctly formatted secret key", func(t *testing.T) {
 		secretKeyListings := []gpgwrapper.KeyListing{
 			gpgwrapper.KeyListing{
-				Fingerprint: fingerprint.MustParse("BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB"),
+				Fingerprint: fpr.MustParse("BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB"),
 				Uids: []string{
 					"Chat Wannamaker<chat2@example.com>",
 					"Chat Rulez<chat3@example.com>",
@@ -134,7 +134,7 @@ func TestPromptForWhichGpgKey(t *testing.T) {
 }
 
 var exampleSecretKey = gpgwrapper.KeyListing{
-	Fingerprint: fingerprint.MustParse("BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB"),
+	Fingerprint: fpr.MustParse("BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB"),
 	Uids: []string{
 		"Chat Wannamaker<chat2@example.com>",
 		"Chat Rulez<chat3@example.com>",

--- a/fk/privatekeys_test.go
+++ b/fk/privatekeys_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fluidkeys/fluidkeys/assert"
 	"github.com/fluidkeys/fluidkeys/exampledata"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/gpgwrapper"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 )
@@ -16,7 +16,7 @@ type mockExportPrivateKey struct {
 	returnError  error
 }
 
-func (m *mockExportPrivateKey) ExportPrivateKey(fingerprint fingerprint.Fingerprint, password string) (string, error) {
+func (m *mockExportPrivateKey) ExportPrivateKey(fingerprint fpr.Fingerprint, password string) (string, error) {
 	return m.returnString, m.returnError
 }
 

--- a/gpgwrapper/gpgwrapper.go
+++ b/gpgwrapper/gpgwrapper.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 
 	"github.com/mitchellh/go-homedir"
 )
@@ -60,7 +60,7 @@ type KeyListing struct {
 	// Fingerprint is the human-readable format of the fingerprint of the
 	// primary key, for example:
 	// `AB01 AB01 AB01 AB01 AB01  AB01 AB01 AB01 AB01 AB01`
-	Fingerprint fingerprint.Fingerprint
+	Fingerprint fpr.Fingerprint
 
 	// Uids is a list of UTF-8 user ID strings as defined in
 	// https://tools.ietf.org/html/rfc4880#section-5.11
@@ -181,7 +181,7 @@ func (g *GnuPG) ListPublicKeys(searchString string) ([]KeyListing, error) {
 
 // ExportPublicKey returns 1 ascii armored public key for the given
 // fingerprint
-func (g *GnuPG) ExportPublicKey(fingerprint fingerprint.Fingerprint) (string, error) {
+func (g *GnuPG) ExportPublicKey(fingerprint fpr.Fingerprint) (string, error) {
 	args := []string{
 		"--export-options", "export-minimal",
 		"--armor",
@@ -213,7 +213,7 @@ func (g *GnuPG) ExportPublicKey(fingerprint fingerprint.Fingerprint) (string, er
 // ExportPrivateKey returns 1 ascii armored private key for the given
 // fingerprint, assuming it is encrypted with the given password.
 // The outputted private key is encrypted with the password.
-func (g *GnuPG) ExportPrivateKey(fingerprint fingerprint.Fingerprint, password string) (string, error) {
+func (g *GnuPG) ExportPrivateKey(fingerprint fpr.Fingerprint, password string) (string, error) {
 
 	stdout, stderr, err := g.run(
 		password,
@@ -246,7 +246,7 @@ func (g *GnuPG) ExportPrivateKey(fingerprint fingerprint.Fingerprint, password s
 	return checkValidExportPrivateOutput(stdout, stderr)
 }
 
-func getArgsExportPrivateKeyWithPinentry(fingerprint fingerprint.Fingerprint) []string {
+func getArgsExportPrivateKeyWithPinentry(fingerprint fpr.Fingerprint) []string {
 	return []string{
 		"--pinentry-mode", "loopback", // don't use OS password prompt
 		"--passphrase-fd", "0", // read password from stdin
@@ -256,7 +256,7 @@ func getArgsExportPrivateKeyWithPinentry(fingerprint fingerprint.Fingerprint) []
 	}
 }
 
-func getArgsExportPrivateKeyWithoutPinentry(fingerprint fingerprint.Fingerprint) []string {
+func getArgsExportPrivateKeyWithoutPinentry(fingerprint fpr.Fingerprint) []string {
 	return []string{
 		"--passphrase-fd", "0", // read password from stdin
 		"--armor",

--- a/gpgwrapper/gpgwrapper_test.go
+++ b/gpgwrapper/gpgwrapper_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/fluidkeys/fluidkeys/assert"
 	"github.com/fluidkeys/fluidkeys/exampledata"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 func TestParseGPGOutputVersion(t *testing.T) {
@@ -130,7 +130,7 @@ func TestListSecretKeys(t *testing.T) {
 	}
 
 	expectedKey := KeyListing{
-		Fingerprint: fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
+		Fingerprint: fpr.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"),
 		Uids:        []string{"test@example.com"},
 		Created:     time.Date(2018, 8, 22, 12, 8, 23, 0, time.UTC),
 	}
@@ -186,7 +186,7 @@ func TestExportPublicKey(t *testing.T) {
 	gpg.ImportArmoredKey(ExamplePrivateKey)
 
 	t.Run("with a valid fingerprint", func(t *testing.T) {
-		_, err := gpg.ExportPublicKey(fingerprint.MustParse("8FBC 0768 76F2 B042 AE2B  A37B 0BBD 7E7E 5B85 C8D3"))
+		_, err := gpg.ExportPublicKey(fpr.MustParse("8FBC 0768 76F2 B042 AE2B  A37B 0BBD 7E7E 5B85 C8D3"))
 
 		if err != nil {
 			t.Errorf("Failed to run ExportPublicKey: %v", err)
@@ -195,7 +195,7 @@ func TestExportPublicKey(t *testing.T) {
 	})
 
 	t.Run("with an invalid fingerprint", func(t *testing.T) {
-		_, err := gpg.ExportPublicKey(fingerprint.MustParse("0000 0000 0000 0000 0000 0000 0000 0000 0000 0000"))
+		_, err := gpg.ExportPublicKey(fpr.MustParse("0000 0000 0000 0000 0000 0000 0000 0000 0000 0000"))
 
 		if err == nil {
 			t.Errorf("ExportPublicKey should have returned an error but didnt")
@@ -209,7 +209,7 @@ func TestExportPrivateKey(t *testing.T) {
 	gpg.ImportArmoredKey(ExamplePrivateKey)
 
 	t.Run("with a valid fingerprint and password", func(t *testing.T) {
-		_, err := gpg.ExportPrivateKey(fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"), "foo")
+		_, err := gpg.ExportPrivateKey(fpr.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"), "foo")
 
 		if err != nil {
 			t.Errorf("Failed to run ExportPrivateKey: %v", err)
@@ -233,7 +233,7 @@ func TestExportPrivateKey(t *testing.T) {
 			t.Skip()
 		}
 
-		output, err := gpg.ExportPrivateKey(fingerprint.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"), "wrong password")
+		output, err := gpg.ExportPrivateKey(fpr.MustParse("C16B 89AC 31CD F3B7 8DA3  3AAE 1D20 FC95 4793 5FC6"), "wrong password")
 
 		if err == nil {
 			t.Errorf("ExportPrivateKey should have returned an error but didnt. output: %s", output)
@@ -245,7 +245,7 @@ func TestExportPrivateKey(t *testing.T) {
 	})
 
 	t.Run("with an invalid fingerprint", func(t *testing.T) {
-		_, err := gpg.ExportPrivateKey(fingerprint.MustParse("0000 0000 0000 0000 0000 0000 0000 0000 0000 0000"), "bar")
+		_, err := gpg.ExportPrivateKey(fpr.MustParse("0000 0000 0000 0000 0000 0000 0000 0000 0000 0000"), "bar")
 
 		if err == nil {
 			t.Errorf("ExportPrivateKey should have returned an error but didnt")

--- a/gpgwrapper/interfaces.go
+++ b/gpgwrapper/interfaces.go
@@ -18,7 +18,7 @@
 package gpgwrapper
 
 import (
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 // ExportPrivateKeyInterface is the interface that wraps the ExportPrivateKey
@@ -28,7 +28,7 @@ import (
 // fingerprint, assuming it is encrypted with the given password.
 // The outputted private key is encrypted with the password.
 type ExportPrivateKeyInterface interface {
-	ExportPrivateKey(fpr fingerprint.Fingerprint, password string) (string, error)
+	ExportPrivateKey(fingerprint fpr.Fingerprint, password string) (string, error)
 }
 
 // ImportArmoredKeyInterface is the interface that wraps the ExportPrivateKey

--- a/gpgwrapper/listpublicparser.go
+++ b/gpgwrapper/listpublicparser.go
@@ -20,7 +20,7 @@ package gpgwrapper
 import (
 	"strings"
 
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 // parseListPublicKeys parses the output of --with-colons --list-keys and returns only valid keys
@@ -119,7 +119,7 @@ func (p *listPublicKeysParser) handleFingerprintLine(cols []string) {
 		// interested in
 		return
 	}
-	fingerprint, err := fingerprint.Parse(cols[9])
+	fingerprint, err := fpr.Parse(cols[9])
 	if err != nil {
 		return
 	}

--- a/gpgwrapper/listpublicparser_test.go
+++ b/gpgwrapper/listpublicparser_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 func TestParseListPublicKeys(t *testing.T) {
@@ -36,7 +36,7 @@ func TestParseListPublicKeys(t *testing.T) {
 		}
 
 		expectedFirst := KeyListing{
-			Fingerprint: fingerprint.MustParse("86FF 75A3 8CB4 756A 5DDC  E541 7A5F DAF6 E82A 2CC6"),
+			Fingerprint: fpr.MustParse("86FF 75A3 8CB4 756A 5DDC  E541 7A5F DAF6 E82A 2CC6"),
 			Created:     time.Date(2019, 02, 21, 14, 34, 57, 0, time.UTC), // 21 Feb 2018 14:34:57
 			Uids: []string{
 				"Joe Smith <joe@example.com>",
@@ -45,7 +45,7 @@ func TestParseListPublicKeys(t *testing.T) {
 		}
 
 		expectedSecond := KeyListing{
-			Fingerprint: fingerprint.MustParse("CFA8 A534 0CCD E66D 633A  9F4E 61A2 89A5 106B 040C"),
+			Fingerprint: fpr.MustParse("CFA8 A534 0CCD E66D 633A  9F4E 61A2 89A5 106B 040C"),
 			Created:     time.Date(2019, 02, 21, 14, 35, 15, 0, time.UTC), // 21 Feb 2018 14:35:15
 			Uids:        []string{"<jane@example.com>"},
 		}

--- a/gpgwrapper/listsecretparser.go
+++ b/gpgwrapper/listsecretparser.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 // parseListSecretKeys parses the output of --with-colons --list-secret keys and return only valid
@@ -124,7 +124,7 @@ func (p *listSecretKeysParser) handleFingerprintLine(cols []string) {
 		// interested in
 		return
 	}
-	fingerprint, err := fingerprint.Parse(cols[9])
+	fingerprint, err := fpr.Parse(cols[9])
 	if err != nil {
 		return
 	}

--- a/gpgwrapper/listsecretparser_test.go
+++ b/gpgwrapper/listsecretparser_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
 func TestParseListSecretKeys(t *testing.T) {
@@ -36,7 +36,7 @@ func TestParseListSecretKeys(t *testing.T) {
 		}
 
 		expectedFirst := KeyListing{
-			Fingerprint: fingerprint.MustParse("A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517"),
+			Fingerprint: fpr.MustParse("A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517"),
 			Created:     time.Date(2014, 10, 31, 21, 34, 34, 0, time.UTC), // 31 October 2014 21:34:34
 			Uids: []string{
 				"Paul Michael Furley <paul@paulfurley.com>",
@@ -45,7 +45,7 @@ func TestParseListSecretKeys(t *testing.T) {
 		}
 
 		expectedSecond := KeyListing{
-			Fingerprint: fingerprint.MustParse("B79F 0840 DEF1 2EBB A72F  F72D 7327 A44C 2157 A758"),
+			Fingerprint: fpr.MustParse("B79F 0840 DEF1 2EBB A72F  F72D 7327 A44C 2157 A758"),
 			Created:     time.Date(2018, 9, 4, 16, 15, 46, 0, time.UTC), // Tue Sep  4 17:15:46 BST 2018
 			Uids:        []string{"<paul@fluidkeys.com>"},
 		}

--- a/keyring/keyring_test.go
+++ b/keyring/keyring_test.go
@@ -3,13 +3,14 @@ package keyring
 import (
 	"fmt"
 	"github.com/fluidkeys/fluidkeys/assert"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
 	externalkeyring "github.com/fluidkeys/keyring"
 	"os"
 	"testing"
+
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
-var exampleFingerprint = fingerprint.MustParse("AAAA1111AAAA1111AAAAAAAA1111AAAA1111AAAA")
+var exampleFingerprint = fpr.MustParse("AAAA1111AAAA1111AAAAAAAA1111AAAA1111AAAA")
 
 func TestLoad(t *testing.T) {
 

--- a/pgpkey/pgpkey.go
+++ b/pgpkey/pgpkey.go
@@ -33,7 +33,7 @@ import (
 	"github.com/fluidkeys/crypto/openpgp/armor"
 	"github.com/fluidkeys/crypto/openpgp/packet"
 	"github.com/fluidkeys/fluidkeys/emailutils"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/openpgpdefs/compression"
 	"github.com/fluidkeys/fluidkeys/openpgpdefs/hash"
 	"github.com/fluidkeys/fluidkeys/openpgpdefs/symmetric"
@@ -408,8 +408,8 @@ func deduplicateEmails(emails []string) []string {
 	return deduplicated
 }
 
-func (key *PgpKey) Fingerprint() fingerprint.Fingerprint {
-	return fingerprint.FromBytes(key.PrimaryKey.Fingerprint)
+func (key *PgpKey) Fingerprint() fpr.Fingerprint {
+	return fpr.FromBytes(key.PrimaryKey.Fingerprint)
 }
 
 func (key *PgpKey) UpdateExpiryForAllUserIds(validUntil time.Time, now time.Time) error {

--- a/pgpkey/pgpkey_test.go
+++ b/pgpkey/pgpkey_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/fluidkeys/fluidkeys/assert"
 	"github.com/fluidkeys/fluidkeys/exampledata"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/policy"
 )
 
@@ -393,7 +393,7 @@ func TestLoadFromArmoredPublicKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFromArmoredPublicKey(..) failed: %v", err)
 	}
-	expected := fingerprint.MustParse("0C10 C4A2 6E9B 1B46 E713  C8D2 BEBF 0628 DAFF 9F4B")
+	expected := fpr.MustParse("0C10 C4A2 6E9B 1B46 E713  C8D2 BEBF 0628 DAFF 9F4B")
 	got := pgpKey.Fingerprint()
 	if got != expected {
 		t.Fatalf("loaded pgp key but it had unexpected fingerprint. exprted: %v, got: %v", expected, got)

--- a/team/roster_test.go
+++ b/team/roster_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/exampledata"
 
 	"github.com/fluidkeys/fluidkeys/assert"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/gofrs/uuid"
 )
 
@@ -20,11 +20,11 @@ func TestParse(t *testing.T) {
 	expectedPeople := []Person{
 		{
 			Email:       "paul@fluidkeys.com",
-			Fingerprint: fingerprint.MustParse("B79F0840DEF12EBBA72FF72D7327A44C2157A758"),
+			Fingerprint: fpr.MustParse("B79F0840DEF12EBBA72FF72D7327A44C2157A758"),
 		},
 		{
 			Email:       "ian@fluidkeys.com",
-			Fingerprint: fingerprint.MustParse("E63AF0E74EB5DE3FB72DC981C991709318ECBDE7"),
+			Fingerprint: fpr.MustParse("E63AF0E74EB5DE3FB72DC981C991709318ECBDE7"),
 		},
 	}
 	assert.Equal(t, expectedPeople, team.People)

--- a/team/team.go
+++ b/team/team.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/gofrs/uuid"
 	"github.com/natefinch/atomic"
 )
@@ -93,7 +93,7 @@ func (t *Team) Validate() error {
 		emailsSeen[person.Email] = true
 	}
 
-	fingerprintsSeen := map[fingerprint.Fingerprint]bool{}
+	fingerprintsSeen := map[fpr.Fingerprint]bool{}
 	for _, person := range t.People {
 		if _, alreadySeen := fingerprintsSeen[person.Fingerprint]; alreadySeen {
 			return fmt.Errorf("fingerprint listed more than once: %s", person.Fingerprint)
@@ -105,9 +105,9 @@ func (t *Team) Validate() error {
 
 // GetPersonForFingerprint takes a fingerprint and returns the person in the team with the
 // matching fingperint.
-func (t *Team) GetPersonForFingerprint(fpr fingerprint.Fingerprint) (*Person, error) {
+func (t *Team) GetPersonForFingerprint(fingerprint fpr.Fingerprint) (*Person, error) {
 	for _, person := range t.People {
-		if person.Fingerprint == fpr {
+		if person.Fingerprint == fingerprint {
 			return &person, nil
 		}
 	}
@@ -179,17 +179,17 @@ type Team struct {
 }
 
 // Fingerprints returns the key fingerprints for all people in the team
-func (t *Team) Fingerprints() []fingerprint.Fingerprint {
-	fps := []fingerprint.Fingerprint{}
+func (t *Team) Fingerprints() []fpr.Fingerprint {
+	fingerprints := []fpr.Fingerprint{}
 
 	for _, person := range t.People {
-		fps = append(fps, person.Fingerprint)
+		fingerprints = append(fingerprints, person.Fingerprint)
 	}
-	return fps
+	return fingerprints
 }
 
 // Person represents a human team member
 type Person struct {
-	Email       string                  `toml:"email"`
-	Fingerprint fingerprint.Fingerprint `toml:"fingerprint"`
+	Email       string          `toml:"email"`
+	Fingerprint fpr.Fingerprint `toml:"fingerprint"`
 }

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/fluidkeys/crypto/openpgp"
 	"github.com/fluidkeys/fluidkeys/assert"
 	"github.com/fluidkeys/fluidkeys/exampledata"
-	"github.com/fluidkeys/fluidkeys/fingerprint"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/gofrs/uuid"
 )
@@ -41,7 +41,7 @@ func TestValidate(t *testing.T) {
 			People: []Person{
 				{
 					Email:       "test@example.com",
-					Fingerprint: fingerprint.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
+					Fingerprint: fpr.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
 				},
 			},
 		}
@@ -56,7 +56,7 @@ func TestValidate(t *testing.T) {
 			People: []Person{
 				{
 					Email:       "test@example.com",
-					Fingerprint: fingerprint.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
+					Fingerprint: fpr.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
 				},
 			},
 		}
@@ -72,11 +72,11 @@ func TestValidate(t *testing.T) {
 			People: []Person{
 				{
 					Email:       "test@example.com",
-					Fingerprint: fingerprint.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
+					Fingerprint: fpr.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
 				},
 				{
 					Email:       "test@example.com",
-					Fingerprint: fingerprint.MustParse("CCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDD"),
+					Fingerprint: fpr.MustParse("CCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDD"),
 				},
 			},
 		}
@@ -92,11 +92,11 @@ func TestValidate(t *testing.T) {
 			People: []Person{
 				{
 					Email:       "test@example.com",
-					Fingerprint: fingerprint.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
+					Fingerprint: fpr.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
 				},
 				{
 					Email:       "another@example.com",
-					Fingerprint: fingerprint.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
+					Fingerprint: fpr.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
 				},
 			},
 		}
@@ -110,11 +110,11 @@ func TestValidate(t *testing.T) {
 func TestGetPersonForFingerprint(t *testing.T) {
 	personOne := Person{
 		Email:       "test@example.com",
-		Fingerprint: fingerprint.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
+		Fingerprint: fpr.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
 	}
 	personTwo := Person{
 		Email:       "another@example.com",
-		Fingerprint: fingerprint.MustParse("CCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDD"),
+		Fingerprint: fpr.MustParse("CCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDD"),
 	}
 
 	team := Team{
@@ -124,7 +124,7 @@ func TestGetPersonForFingerprint(t *testing.T) {
 	}
 
 	t.Run("with a team member with matching fingerprint", func(t *testing.T) {
-		got, err := team.GetPersonForFingerprint(fingerprint.MustParse(
+		got, err := team.GetPersonForFingerprint(fpr.MustParse(
 			"AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"))
 
 		assert.NoError(t, err)
@@ -132,7 +132,7 @@ func TestGetPersonForFingerprint(t *testing.T) {
 	})
 
 	t.Run("with no matching fingerprints", func(t *testing.T) {
-		_, err := team.GetPersonForFingerprint(fingerprint.MustParse(
+		_, err := team.GetPersonForFingerprint(fpr.MustParse(
 			"EEEEFFFFEEEEFFFFEEEEFFFFEEEEFFFFEEEEFFFF"))
 
 		assert.Equal(t, fmt.Errorf("person not found"), err)
@@ -164,7 +164,7 @@ func TestSignAndSave(t *testing.T) {
 			People: []Person{
 				{
 					Email:       "test@example.com",
-					Fingerprint: fingerprint.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
+					Fingerprint: fpr.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
 				},
 			},
 		}
@@ -256,7 +256,7 @@ name = "Kiffix"
 			People: []Person{
 				{
 					Email:       "test@example.com",
-					Fingerprint: fingerprint.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
+					Fingerprint: fpr.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
 				},
 			},
 		}


### PR DESCRIPTION
We should always refer to the `fingerprint` package as `fpr`. 