### PR TITLE
add RosterSaver

### DIFF
--- a/team/rostersaver.go
+++ b/team/rostersaver.go
@@ -1,0 +1,169 @@
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package team
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// RosterSaver provides a way to do a 2-part save where a roster is saved as a "draft"
+// which can be either committed or discarded.
+type RosterSaver struct {
+	Directory string
+
+	draftRosterFilename    string
+	draftSignatureFilename string
+}
+
+// Save saves the roster and signature straight to disk.
+func (rs *RosterSaver) Save(roster string, signature string) error {
+	if err := rs.SaveDraft(roster, signature); err != nil {
+		return err
+	}
+	if err := rs.CommitDraft(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SaveDraft saves the roster and signature to temporary files. This call should be followed by
+// either CommitDraft() or DiscardDraft() to actually write or delete the roster & signature.
+func (rs *RosterSaver) SaveDraft(roster string, signature string) error {
+	if rs.draftRosterFilename != "" || rs.draftSignatureFilename != "" {
+		return fmt.Errorf("already have a draft in progress")
+	}
+
+	if err := os.MkdirAll(rs.Directory, 0700); err != nil {
+		return fmt.Errorf("failed to make directory %s: %v", rs.Directory, err)
+	}
+
+	rosterTmp, err := ioutil.TempFile(rs.Directory, ".tmp."+rosterFilename)
+	if err != nil {
+		return err
+	}
+	defer rosterTmp.Close()
+
+	if _, err := rosterTmp.Write([]byte(roster)); err != nil {
+		_ = os.Remove(rosterTmp.Name()) // best effort to clean up, but don't check error
+		return err
+	}
+
+	sigTmp, err := ioutil.TempFile(rs.Directory, ".tmp."+signatureFilename)
+	if err != nil {
+		_ = os.Remove(rosterTmp.Name()) // best effort to clean up, but don't check error
+		return err
+	}
+	defer sigTmp.Close()
+
+	if _, err := sigTmp.Write([]byte(signature)); err != nil {
+		_ = os.Remove(rosterTmp.Name()) // best effort to clean up, but don't check error
+		_ = os.Remove(sigTmp.Name())
+		return err
+	}
+
+	rs.draftRosterFilename = rosterTmp.Name()
+	rs.draftSignatureFilename = sigTmp.Name()
+	return nil
+}
+
+// CommitDraft actually saves the previously saved draft roster and signature
+func (rs *RosterSaver) CommitDraft() error {
+	if rs.draftRosterFilename == "" || rs.draftSignatureFilename == "" {
+		return fmt.Errorf("no draft in progress")
+	}
+
+	rosterFilename := filepath.Join(rs.Directory, rosterFilename)
+	rosterBackupFilename := filepath.Join(rs.Directory, rosterBackupFilename)
+	signatureFilename := filepath.Join(rs.Directory, signatureFilename)
+
+	isUpdate := fileExists(rosterFilename)
+
+	if isUpdate {
+		// backup roster.toml to roster.toml.BAK
+		if err := os.Rename(rosterFilename, rosterBackupFilename); err != nil {
+			return err
+		}
+	}
+
+	// move draft roster -> roster.toml
+	if err := os.Rename(rs.draftRosterFilename, rosterFilename); err != nil {
+		// failed to write new roster.toml, so try to restore backup (if we made one)
+
+		if isUpdate {
+			if err2 := os.Rename(rosterBackupFilename, rosterFilename); err2 != nil {
+				return fmt.Errorf("failed to write %s (%v) and failed to restore backup %s (%v)",
+					rosterFilename, err, rosterBackupFilename, err2)
+			}
+		}
+		return err
+	}
+	rs.draftRosterFilename = ""
+
+	// move draft signature -> roster.toml.asc
+	if err := os.Rename(rs.draftSignatureFilename, signatureFilename); err != nil {
+		log.Printf("failed to mv %s -> %s: %v", rs.draftSignatureFilename, signatureFilename, err)
+
+		// signature failed to write, so now the roster and the signature are out of sync.
+		// try to restore the backup of the roster
+
+		if isUpdate {
+			log.Printf("attempting to restore %s -> %s", rosterBackupFilename, rosterFilename)
+
+			if err2 := os.Rename(rosterBackupFilename, rosterFilename); err2 != nil {
+				return fmt.Errorf("failed to write %s (%v) *and* then failed to roll back %s (%v)",
+					signatureFilename, err, rosterBackupFilename, err2)
+			}
+		} else {
+			// the roster was brand new (it didn't exist at the start of the call) so now delete it
+			// to be back in sync with the signature
+
+			log.Printf("attempting to delete (new) %s", rosterFilename)
+
+			_ = os.Remove(rosterFilename)
+		}
+
+		return err
+	}
+	rs.draftSignatureFilename = ""
+
+	return nil
+}
+
+// DiscardDraft deletes the previously saved draft roster and signature
+func (rs *RosterSaver) DiscardDraft() error {
+	if rs.draftRosterFilename == "" || rs.draftSignatureFilename == "" {
+		return fmt.Errorf("no draft in progress")
+	}
+
+	_ = os.Remove(rs.draftRosterFilename)
+	_ = os.Remove(rs.draftSignatureFilename)
+
+	rs.draftRosterFilename = ""
+	rs.draftSignatureFilename = ""
+	return nil
+}
+
+const (
+	rosterFilename       = "roster.toml"
+	rosterBackupFilename = "roster.toml.BAK"
+	signatureFilename    = "roster.toml.asc"
+)

--- a/team/rostersaver_test.go
+++ b/team/rostersaver_test.go
@@ -1,0 +1,201 @@
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package team
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+)
+
+func TestCommitDraft(t *testing.T) {
+
+	t.Run("saves files when they don't already exist", func(t *testing.T) {
+		rosterSaver := makeRosterSaveInTmpDirectory(t)
+		defer os.RemoveAll(rosterSaver.Directory)
+
+		err := rosterSaver.SaveDraft("fake roster", "fake signature")
+		assert.NoError(t, err)
+
+		err = rosterSaver.CommitDraft()
+		assert.NoError(t, err)
+
+		t.Run("roster.toml", func(t *testing.T) {
+			assert.Equal(t,
+				"fake roster",
+				readFile(t, filepath.Join(rosterSaver.Directory, "roster.toml")),
+			)
+		})
+
+		t.Run("roster.toml.asc", func(t *testing.T) {
+			assert.Equal(t,
+				"fake signature",
+				readFile(t, filepath.Join(rosterSaver.Directory, "roster.toml.asc")),
+			)
+		})
+
+		t.Run("clears the draft filename", func(t *testing.T) {
+			assert.Equal(t, "", rosterSaver.draftRosterFilename)
+			assert.Equal(t, "", rosterSaver.draftSignatureFilename)
+		})
+	})
+
+	t.Run("overwrites if a file already exists", func(t *testing.T) {
+		rosterSaver := makeRosterSaveInTmpDirectory(t)
+		defer os.RemoveAll(rosterSaver.Directory)
+
+		err := rosterSaver.SaveDraft("roster 1", "signature 1")
+		assert.NoError(t, err)
+
+		err = rosterSaver.CommitDraft()
+		assert.NoError(t, err)
+
+		err = rosterSaver.SaveDraft("roster 2", "signature 2")
+		assert.NoError(t, err)
+
+		err = rosterSaver.CommitDraft()
+		assert.NoError(t, err)
+
+		t.Run("roster.toml", func(t *testing.T) {
+			assert.Equal(t,
+				"roster 2",
+				readFile(t, filepath.Join(rosterSaver.Directory, "roster.toml")),
+			)
+		})
+
+		t.Run("roster.toml.asc", func(t *testing.T) {
+			assert.Equal(t,
+				"signature 2",
+				readFile(t, filepath.Join(rosterSaver.Directory, "roster.toml.asc")),
+			)
+		})
+	})
+
+	t.Run("returns error if roster can't be written", func(t *testing.T) {
+
+		t.Run("leaves original roster intact", func(t *testing.T) {
+		})
+	})
+
+	t.Run("deletes new roster if signature can't be saved", func(t *testing.T) {
+		rosterSaver := makeRosterSaveInTmpDirectory(t)
+		defer os.RemoveAll(rosterSaver.Directory)
+
+		rosterFilename := filepath.Join(rosterSaver.Directory, "roster.toml")
+		//sigFilename := filepath.Join(rosterSaver.Directory, "roster.toml.asc")
+
+		err := rosterSaver.SaveDraft("roster 1", "signature 1")
+		assert.NoError(t, err)
+
+		// fudge it so the attempt fails to move draft signature -> roster.toml.asc
+		assert.NoError(t, os.Remove(rosterSaver.draftSignatureFilename))
+
+		err = rosterSaver.CommitDraft()
+		assert.GotError(t, err)
+
+		if fileExists(rosterFilename) {
+			t.Fatalf("%s should have been deleted, but it exists", rosterFilename)
+		}
+
+	})
+
+	t.Run("rolls back to previous existing roster if signature can't be saved", func(t *testing.T) {
+		rosterSaver := makeRosterSaveInTmpDirectory(t)
+		defer os.RemoveAll(rosterSaver.Directory)
+
+		err := rosterSaver.Save("original roster", "original signature")
+		assert.NoError(t, err)
+
+		err = rosterSaver.SaveDraft("updated roster", "updated signature")
+		assert.NoError(t, err)
+
+		// fudge it so the attempt fails to move draft signature -> roster.toml.asc
+		assert.NoError(t, os.Remove(rosterSaver.draftSignatureFilename))
+
+		err = rosterSaver.CommitDraft()
+		assert.GotError(t, err)
+
+		assert.Equal(t,
+			"original roster",
+			readFile(t, filepath.Join(rosterSaver.Directory, "roster.toml")),
+		)
+
+		assert.Equal(t,
+			"original signature",
+			readFile(t, filepath.Join(rosterSaver.Directory, "roster.toml.asc")),
+		)
+
+	})
+
+	t.Run("errors if a draft isn't in progress", func(t *testing.T) {
+		rosterSaver := makeRosterSaveInTmpDirectory(t)
+		defer os.RemoveAll(rosterSaver.Directory)
+
+		err := rosterSaver.CommitDraft()
+		assert.GotError(t, err)
+		assert.Equal(t, fmt.Errorf("no draft in progress"), err)
+	})
+}
+
+func TestDiscardDraft(t *testing.T) {
+
+	t.Run("deletes temp files and clears variables", func(t *testing.T) {
+		rosterSaver := makeRosterSaveInTmpDirectory(t)
+		defer os.RemoveAll(rosterSaver.Directory)
+
+		rosterSaver.SaveDraft("roster", "signature")
+
+		rosterTmpFilename := rosterSaver.draftRosterFilename
+		signatureTmpFilename := rosterSaver.draftSignatureFilename
+
+		err := rosterSaver.DiscardDraft()
+		assert.NoError(t, err)
+
+		assert.Equal(t, "", rosterSaver.draftRosterFilename)
+		assert.Equal(t, "", rosterSaver.draftSignatureFilename)
+
+		if fileExists(rosterTmpFilename) {
+			t.Fatalf("discard hasn't deleted %s", rosterTmpFilename)
+		}
+
+		if fileExists(signatureTmpFilename) {
+			t.Fatalf("discard hasn't deleted %s", signatureTmpFilename)
+		}
+
+	})
+}
+
+func makeRosterSaveInTmpDirectory(t *testing.T) RosterSaver {
+	t.Helper()
+	tmpDirectory, err := ioutil.TempDir("", "fktest")
+	assert.NoError(t, err)
+
+	return RosterSaver{
+		Directory: tmpDirectory,
+	}
+}
+
+func readFile(t *testing.T, filename string) string {
+	content, err := ioutil.ReadFile(filename)
+	assert.NoError(t, err)
+	return string(content)
+}


### PR DESCRIPTION
this lets you do a 2-stage save, with some other (fallible) task in the
middle:

``` rosterSaver := RosterSaver{Directory: teamSubdirectory}

rosterSaver.SaveDraft(roster, signature)

if err := api.UpdateRoster(roster, signature); err != nil {
   rosterSaver.DiscardDraft()
}

rosterSaver.CommitDraft()
```