### PR TITLE
fix line spacing when itterating over requests

### DIFF
--- a/fk/teamauthorize.go
+++ b/fk/teamauthorize.go
@@ -164,6 +164,8 @@ func reviewRequests(myTeam team.Team, adminKey pgpkey.PgpKey) (
 					nil,
 				))
 			}
+		} else {
+			out.Print("\n")
 		}
 
 		addToTeam := prompter.promptYesNo("Authorize this key for "+request.Email+


### PR DESCRIPTION
ui.Formatxxx() adds a newline (\n) at the top of every dialog
box. If we don't have any error, we should make sure we also add
this new line in, so the requests are spaced properly.

Before:
![Screenshot 2019-03-18 at 10 58 55](https://user-images.githubusercontent.com/55195/54525778-dd52d680-496c-11e9-9a29-604dd516833c.png)

After:
![Screenshot 2019-03-18 at 10 58 32](https://user-images.githubusercontent.com/55195/54525785-e17ef400-496c-11e9-950e-5a75d891fea7.png)
