### PR TITLE
remove extra new line on `team join`

### DIFF
--- a/fk/teamjoin.go
+++ b/fk/teamjoin.go
@@ -61,7 +61,7 @@ func teamJoin(teamUUID uuid.UUID) exitCode {
 	}
 
 	ui.PrintCheckboxSuccess(action)
-	out.Print("\n\n")
+	out.Print("\n")
 
 	out.Print("Your team admin will need to authorize your request for Fluidkeys to\n" +
 		"start working.\n\n")


### PR DESCRIPTION
We never double space and ui.PrintCheckboxSuccess includes a \n
at the end.

I noticed this when recording the demo for weeknotes, it looked like this:
![Screenshot 2019-03-18 at 11 03 03](https://user-images.githubusercontent.com/55195/54526063-7e419180-496d-11e9-963b-9814afcc651b.png)
