### PR TITLE
fk team sync: get & verify new roster & keys

### DIFF
--- a/fk/teamsync.go
+++ b/fk/teamsync.go
@@ -27,6 +27,7 @@ import (
 	fp "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/humanize"
 	"github.com/fluidkeys/fluidkeys/out"
+	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/fluidkeys/fluidkeys/team"
 	"github.com/fluidkeys/fluidkeys/ui"
 )
@@ -109,4 +110,16 @@ func getAndImportKeyToGpg(fingerprint fp.Fingerprint) error {
 		return fmt.Errorf("Failed to import key into gpg")
 	}
 	return nil
+}
+
+func fetchAdminPublicKeys(t team.Team) (adminKeys []*pgpkey.PgpKey, err error) {
+	for _, p := range t.Admins() {
+		key, err := client.GetPublicKeyByFingerprint(p.Fingerprint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get admin key %s: %v", p.Fingerprint, err)
+		}
+
+		adminKeys = append(adminKeys, key)
+	}
+	return adminKeys, nil
 }

--- a/fk/teamsync.go
+++ b/fk/teamsync.go
@@ -73,6 +73,19 @@ func formatYouRequestedToJoin(request team.RequestToJoinTeam) string {
 		humanize.RoughDuration(time.Now().Sub(request.RequestedAt)) + " ago."
 }
 
+func fetchTeamKeys(t team.Team) (err error) {
+	out.Print("Fetching keys for other members of " + t.Name + ":\n\n")
+
+	for _, person := range t.People {
+		err = ui.RunWithCheckboxes(person.Email, func() error {
+			return getAndImportKeyToGpg(person.Fingerprint)
+		})
+		// keep trying subsequent keys even if we hit an error.
+	}
+	out.Print("\n")
+	return err
+}
+
 func getAndImportKeyToGpg(fingerprint fp.Fingerprint) error {
 	key, err := client.GetPublicKeyByFingerprint(fingerprint)
 

--- a/fk/teamsync.go
+++ b/fk/teamsync.go
@@ -123,3 +123,14 @@ func fetchAdminPublicKeys(t team.Team) (adminKeys []*pgpkey.PgpKey, err error) {
 	}
 	return adminKeys, nil
 }
+
+// verifyBrandNewRoster fetches the public keys of the admins in the team and verifies the roster
+// against them.
+func verifyBrandNewRoster(t team.Team, roster string, signature string) error {
+	adminKeys, err := fetchAdminPublicKeys(t)
+	if err != nil {
+		return err
+	}
+
+	return team.VerifyRoster(roster, signature, adminKeys)
+}


### PR DESCRIPTION
this handles the happy path and *most* other paths for joining a new team
(based on requests to join a team)

things to note:

* new rosters are cryptographically validated. this requires downloading
 the admin keys from the API by fingerprint. the behaviour for
 validating an *update* will be different

* requests time out after 7 days. this is currently implemented in
 `fk team sync` but I think I'll move it to database in a subsequent PR
 (along with de-duplicating requests)

* requests are deleted from our local db if they succeed

* content should match our Google doc:
https://docs.google.com/document/d/1FHQXHP7X8Uvtvn72OqZNVYyFMocrJ2MM1zWtYTM4d0c/edit#heading=h.htvwu2p78dq