### PR TITLE
de-duplicate in RecordRequestToJoinTeam, GetRequestsToJoinTeams

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
@@ -130,7 +131,7 @@ func (db *Database) GetRequestsToJoinTeams() (requests []team.RequestToJoinTeam,
 		return nil, err
 	}
 
-	for _, msg := range message.RequestsToJoinTeams {
+	for _, msg := range deduplicateRequests(message.RequestsToJoinTeams) {
 		requests = append(requests, team.RequestToJoinTeam{
 			TeamUUID:    msg.TeamUUID,
 			TeamName:    msg.TeamName,
@@ -224,6 +225,35 @@ func (db Database) saveToFile(message Message) error {
 	encoder.SetIndent("", "    ")
 
 	return encoder.Encode(message)
+}
+
+// deduplicateRequests returns a de-duplicated version of requests, where a duplicate is defined
+// as having the same (TeamUUID + Fingerprint) pair.
+// The *oldest* RequestedAt defines the single request that's returned.
+func deduplicateRequests(requests []RequestToJoinTeamMessage) (deduped []RequestToJoinTeamMessage) {
+	mapHash := func(r RequestToJoinTeamMessage) string {
+		return fmt.Sprintf("%s%s", r.TeamUUID, r.Fingerprint)
+	}
+
+	reqsMap := map[string][]RequestToJoinTeamMessage{}
+
+	for _, r := range requests {
+		hash := mapHash(r)
+
+		if existing, ok := reqsMap[hash]; ok {
+			reqsMap[hash] = append(existing, r)
+		} else {
+			reqsMap[hash] = []RequestToJoinTeamMessage{r}
+		}
+	}
+
+	for _, dupeRequests := range reqsMap {
+		sort.Sort(earliestFirst(dupeRequests))
+		deduped = append(deduped, dupeRequests[0] /* 0th is the earliest */)
+	}
+
+	sort.Sort(earliestFirst(deduped))
+	return deduped
 }
 
 func deduplicateKeyImportedIntoGnuPGMessages(slice []KeyImportedIntoGnuPGMessage,

--- a/database/database.go
+++ b/database/database.go
@@ -98,7 +98,9 @@ func (db *Database) RecordRequestToJoinTeam(
 		RequestedAt: now,
 	}
 
-	message.RequestsToJoinTeams = append(message.RequestsToJoinTeams, newRequest)
+	message.RequestsToJoinTeams = deduplicateRequests(
+		append(message.RequestsToJoinTeams, newRequest),
+	)
 
 	return db.saveToFile(*message)
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -135,6 +135,24 @@ func TestRecordRequestsToJoinTeamG(t *testing.T) {
 		})
 	})
 
+	t.Run("record deduplicates selecting oldest requests for team & fingerprint", func(t *testing.T) {
+		database := New(makeTempDirectory(t))
+
+		dupeReq := request1
+		dupeReq.RequestedAt = later // older one should get dropped
+
+		addRequestToJoinToDatabase(t, request1, database)
+		addRequestToJoinToDatabase(t, dupeReq, database)
+
+		t.Run("and we can read back a matching request ", func(t *testing.T) {
+			gotRequests, err := database.GetRequestsToJoinTeams()
+			assert.NoError(t, err)
+
+			expectedRequests := []team.RequestToJoinTeam{request1}
+			assert.Equal(t, expectedRequests, gotRequests)
+		})
+	})
+
 	t.Run("doesn't overwrite keys imported into gnupg when recording a request to join a team", func(t *testing.T) {
 		fingerprint := exampleFingerprintA
 		database := New(makeTempDirectory(t))

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -77,19 +77,15 @@ func TestRecordRequestsToJoinTeamG(t *testing.T) {
 	request1 := team.RequestToJoinTeam{
 		TeamUUID:    uuid.Must(uuid.NewV4()),
 		TeamName:    "Example",
-		UUID:        uuid.UUID{}, // empty *request* UUID, we don't store that
 		Fingerprint: fingerprint,
 		RequestedAt: now,
-		Email:       "",
 	}
 
 	request2 := team.RequestToJoinTeam{
 		TeamUUID:    uuid.Must(uuid.NewV4()),
 		TeamName:    "Example",
-		UUID:        uuid.UUID{}, // empty *request* UUID, we don't store that
 		Fingerprint: exampledata.ExampleFingerprint3,
 		RequestedAt: later,
-		Email:       "",
 	}
 
 	t.Run("record works to an empty database", func(t *testing.T) {
@@ -164,10 +160,8 @@ func TestGetRequestsToJoinTeams(t *testing.T) {
 
 	request1 := team.RequestToJoinTeam{
 		TeamUUID:    uuid.Must(uuid.NewV4()),
-		UUID:        uuid.UUID{}, // empty *request* UUID, we don't store that
 		Fingerprint: fingerprint,
 		RequestedAt: now,
-		Email:       "",
 	}
 
 	t.Run("can read back requests to join team written to database", func(t *testing.T) {
@@ -255,28 +249,22 @@ func TestGetExistingRequestToJoinTeam(t *testing.T) {
 
 	request1 := team.RequestToJoinTeam{
 		TeamUUID:    team1UUID,
-		UUID:        uuid.UUID{}, // empty *request* UUID, we don't store that
 		Fingerprint: exampleFingerprintA,
 		RequestedAt: now,
-		Email:       "",
 	}
 
 	request2 := team.RequestToJoinTeam{
 		TeamUUID:    team1UUID,
-		UUID:        uuid.UUID{}, // empty *request* UUID, we don't store that
 		Fingerprint: exampleFingerprintB,
 		RequestedAt: now,
-		Email:       "",
 	}
 
 	team2UUID := uuid.Must(uuid.NewV4())
 
 	request3 := team.RequestToJoinTeam{
 		TeamUUID:    team2UUID,
-		UUID:        uuid.UUID{}, // empty *request* UUID, we don't store that
 		Fingerprint: exampleFingerprintA,
 		RequestedAt: now,
-		Email:       "",
 	}
 
 	t.Run("gets the request for the matching teamUUID and fingerprint", func(t *testing.T) {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -73,8 +73,6 @@ func TestGetFingerprintsImportedIntoGnuPG(t *testing.T) {
 func TestRecordRequestsToJoinTeamG(t *testing.T) {
 
 	fingerprint := exampledata.ExampleFingerprint2
-	now := time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
-	later := now.Add(time.Duration(1) * time.Hour)
 
 	request1 := team.RequestToJoinTeam{
 		TeamUUID:    uuid.Must(uuid.NewV4()),
@@ -163,7 +161,6 @@ func TestRecordRequestsToJoinTeamG(t *testing.T) {
 
 func TestGetRequestsToJoinTeams(t *testing.T) {
 	fingerprint := exampledata.ExampleFingerprint2
-	now := time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
 
 	request1 := team.RequestToJoinTeam{
 		TeamUUID:    uuid.Must(uuid.NewV4()),
@@ -194,8 +191,6 @@ func TestGetRequestsToJoinTeams(t *testing.T) {
 }
 
 func TestDeleteRequestToJoinTeam(t *testing.T) {
-	now := time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
-	later := now.Add(time.Duration(10) * time.Minute)
 
 	req1 := team.RequestToJoinTeam{
 		TeamUUID:    uuid.Must(uuid.NewV4()),
@@ -381,6 +376,11 @@ func containsRequest(s []team.RequestToJoinTeam, e team.RequestToJoinTeam) bool 
 	}
 	return false
 }
+
+var (
+	now   = time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
+	later = now.Add(time.Duration(1) * time.Hour)
+)
 
 var exampleFingerprintA = fpr.MustParse("AAAA AAAA AAAA AAAA AAAA  AAAA AAAA AAAA AAAA AAAA")
 var exampleFingerprintB = fpr.MustParse("BBBB BBBB BBBB BBBB BBBB  BBBB BBBB BBBB BBBB BBBB")

--- a/database/sort.go
+++ b/database/sort.go
@@ -1,0 +1,9 @@
+package database
+
+// earliestFirst implements sort.Interface for []RequestToJoinTeamMessage based on
+// the RequestedAt field.
+type earliestFirst []RequestToJoinTeamMessage
+
+func (a earliestFirst) Len() int           { return len(a) }
+func (a earliestFirst) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a earliestFirst) Less(i, j int) bool { return a[i].RequestedAt.Before(a[j].RequestedAt) }


### PR DESCRIPTION
do a bit of test tidy-up:
* delete zero-value initializations: they have no effect, and just distract from the tests
* factor out `now` and `later`