### PR TITLE
rename `fk team sync` -> `fk team fetch`

### DIFF
--- a/fk/main.go
+++ b/fk/main.go
@@ -69,7 +69,7 @@ Usage:
 	fk team create
 	fk team join <uuid>
 	fk team authorize
-	fk team sync [--cron-output]
+	fk team fetch [--cron-output]
 	fk secret send <recipient-email>
 	fk secret send [<filename>] --to=<email>
 	fk secret receive

--- a/fk/team.go
+++ b/fk/team.go
@@ -28,7 +28,7 @@ import (
 
 func teamSubcommand(args docopt.Opts) exitCode {
 	switch getSubcommand(args, []string{
-		"authorize", "create", "join", "sync",
+		"authorize", "create", "join", "fetch",
 	}) {
 
 	case "join":
@@ -45,8 +45,8 @@ func teamSubcommand(args docopt.Opts) exitCode {
 
 		return teamJoin(teamUUID)
 
-	case "sync":
-		return teamSync()
+	case "fetch":
+		return teamFetch()
 
 	case "create":
 		return teamCreate()

--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -33,7 +33,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/ui"
 )
 
-func teamSync() exitCode {
+func teamFetch() exitCode {
 	sawError := false
 
 	myTeams, err := team.LoadTeams(fluidkeysDirectory)

--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -55,13 +55,13 @@ func teamFetch() exitCode {
 			continue
 		}
 
-		out.Print(
-			ui.FormatSuccess("Successfully fetched keys and imported them into GnuPG",
-				[]string{
-					"You have successfully synced keys with the other members of " +
-						existingTeam.Name + ".",
-				},
-			))
+		out.Print(ui.FormatSuccess(
+			successfullyFetchedKeysHeadline,
+			[]string{
+				"You have successfully fetched everyone's key in " +
+					existingTeam.Name + ".",
+			},
+		))
 
 	}
 
@@ -78,15 +78,15 @@ func teamFetch() exitCode {
 			continue
 		}
 
-		out.Print(
-			ui.FormatSuccess("Successfully synced team",
-				[]string{
-					"You have successfully synced keys with the other members of " +
-						newTeam.Name + ".",
-					"This means that you can now start sending and receiving secrets and",
-					"using other GnuPG powered tools together.",
-				},
-			))
+		out.Print(ui.FormatSuccess(
+			successfullyFetchedKeysHeadline,
+			[]string{
+				"You have successfully fetched everyone's key in " +
+					newTeam.Name + ".",
+				"This means that you can now start sending and receiving secrets and",
+				"using other GnuPG powered tools together.",
+			},
+		))
 
 	}
 
@@ -276,3 +276,7 @@ func verifyBrandNewRoster(t team.Team, roster string, signature string) error {
 
 	return team.VerifyRoster(roster, signature, adminKeys)
 }
+
+const (
+	successfullyFetchedKeysHeadline = "Successfully fetched keys and imported them into GnuPG"
+)


### PR DESCRIPTION
update content for "fetch" verb: factor out the headline so we use it consistently