### PR TITLE
api.GetTeamRoster: take pointer to PgpKey

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -256,7 +256,7 @@ func (c *Client) GetTeamName(teamUUID uuid.UUID) (string, error) {
 
 // GetTeamRoster attempts to get the team roster and signature for the given UUID. The API
 // responds with encrypted JSON, so it tries to decrypt this using the requestingKey.
-func (c *Client) GetTeamRoster(requestingKey pgpkey.PgpKey, teamUUID uuid.UUID) (
+func (c *Client) GetTeamRoster(requestingKey *pgpkey.PgpKey, teamUUID uuid.UUID) (
 	roster string, signature string, err error) {
 
 	path := fmt.Sprintf("team/%s/roster", teamUUID)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -442,7 +442,7 @@ func TestGetTeamRoster(t *testing.T) {
 			mockResponseHandler,
 		)
 
-		gotRoster, gotSignature, err := client.GetTeamRoster(*requesterKey, teamUUID)
+		gotRoster, gotSignature, err := client.GetTeamRoster(requesterKey, teamUUID)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedRoster, gotRoster)
@@ -468,7 +468,7 @@ func TestGetTeamRoster(t *testing.T) {
 			mockResponseHandler,
 		)
 
-		_, _, err = client.GetTeamRoster(*invalidRequesterKey, invalidKeyTeamUUID)
+		_, _, err = client.GetTeamRoster(invalidRequesterKey, invalidKeyTeamUUID)
 
 		assert.GotError(t, err)
 		assert.Equal(t,
@@ -488,7 +488,7 @@ func TestGetTeamRoster(t *testing.T) {
 			mockNotFoundResponseHandler,
 		)
 
-		_, _, err := client.GetTeamRoster(*requesterKey, unknownUUID)
+		_, _, err := client.GetTeamRoster(requesterKey, unknownUUID)
 
 		assert.Equal(t, ErrTeamNotFound, err)
 	})
@@ -505,7 +505,7 @@ func TestGetTeamRoster(t *testing.T) {
 			mockResponseHandler,
 		)
 
-		_, _, err := client.GetTeamRoster(*requesterKey, teamUUID)
+		_, _, err := client.GetTeamRoster(requesterKey, teamUUID)
 
 		assert.Equal(t, ErrForbidden, err)
 	})
@@ -522,7 +522,7 @@ func TestGetTeamRoster(t *testing.T) {
 			mockErrorResponseHandler,
 		)
 
-		_, _, err := client.GetTeamRoster(*requesterKey, errorUUID)
+		_, _, err := client.GetTeamRoster(requesterKey, errorUUID)
 
 		assert.GotError(t, err)
 		assert.Equal(t, fmt.Errorf("API error: 500"), err)

--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -165,7 +165,7 @@ func processRequestsToJoinTeam() (newTeams []team.Team, returnError error) {
 			continue
 		}
 
-		roster, signature, err := client.GetTeamRoster(*unlockedKey, request.TeamUUID)
+		roster, signature, err := client.GetTeamRoster(unlockedKey, request.TeamUUID)
 
 		if err == api.ErrForbidden {
 			out.Print(ui.FormatInfo(


### PR DESCRIPTION
we normally do this by convention for the PgpKey, but specifically:

* it's quite a large struct
* it prevents lots of copies of the private key in memory
* if we *unlock* a PgpKey (with a password) it mutates the object, and
  any copies of it therefore aren't unlocked