### PR TITLE
Make `IsInTeam` return a pointer to the team

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -78,17 +78,17 @@ func (u User) Memberships() (teamMemberships []TeamMembership, err error) {
 }
 
 // IsInTeam returns true if *any* of the users keys are in the team with the given UUID.
-func (u User) IsInTeam(teamUUID uuid.UUID) (isInTeam bool, err error) {
+func (u User) IsInTeam(teamUUID uuid.UUID) (isInTeam bool, theTeam *team.Team, err error) {
 	memberships, err := u.Memberships()
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 	for _, membership := range memberships {
 		if membership.Team.UUID == teamUUID {
-			return true, nil
+			return true, &membership.Team, nil
 		}
 	}
-	return false, nil
+	return false, nil, nil
 }
 
 // TeamMembership records a connection between a Person and a Team. It's possible for several of

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -79,13 +79,33 @@ func TestMembershipFunctions(t *testing.T) {
 	})
 
 	t.Run("InTeam", func(t *testing.T) {
-		got, err := user.IsInTeam(team1.UUID)
-		assert.NoError(t, err)
-		assert.Equal(t, true, got)
+		t.Run("user is in team", func(t *testing.T) {
+			gotIsInTeam, gotTeam, err := user.IsInTeam(team1.UUID)
+			assert.NoError(t, err)
 
-		got, err = user.IsInTeam(team2.UUID)
-		assert.NoError(t, err)
-		assert.Equal(t, false, got)
+			t.Run("returns true", func(t *testing.T) {
+				assert.Equal(t, true, gotIsInTeam)
+			})
+
+			t.Run("returns a pointer to the team", func(t *testing.T) {
+				assert.Equal(t, &team1, gotTeam)
+			})
+		})
+
+		t.Run("user is not in team", func(t *testing.T) {
+			gotIsInTeam, gotTeam, err := user.IsInTeam(team2.UUID)
+			assert.NoError(t, err)
+
+			t.Run("returns true", func(t *testing.T) {
+				assert.Equal(t, false, gotIsInTeam)
+			})
+
+			t.Run("returns nil", func(t *testing.T) {
+				if gotTeam != nil {
+					t.Fatalf("expected gotTeam to be nil, but it isn't")
+				}
+			})
+		})
 	})
 
 }


### PR DESCRIPTION
This means that that calling function can do things like:

```
isInTeam, team, err := user.IsInTeam(uuid)
...
if isInTeam {
   fmt.Printf("You're already in %s", team.Name)
}
```