### PR TITLE
Block `team create` and `join` if already in team

### DIFF
--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -33,6 +33,10 @@ import (
 )
 
 func teamCreate() exitCode {
+	if code := ensureUserIsntInATeam("Couldn't create team"); code > 0 {
+		return code
+	}
+
 	out.Print("\n")
 
 	out.Print("A Team is a group of people using Fluidkeys together.\n\n")

--- a/fk/teamjoin.go
+++ b/fk/teamjoin.go
@@ -31,6 +31,10 @@ import (
 )
 
 func teamJoin(teamUUID uuid.UUID) exitCode {
+	if code := ensureUserIsntInATeam("Couldn't request to join team"); code > 0 {
+		return code
+	}
+
 	teamName, err := client.GetTeamName(teamUUID)
 	if err != nil {
 		out.Print(ui.FormatFailure("Couldn't request to join team", nil, err))
@@ -67,6 +71,21 @@ func teamJoin(teamUUID uuid.UUID) exitCode {
 		"start working.\n\n")
 	return 0
 
+}
+
+func ensureUserIsntInATeam(failureHeadline string) exitCode {
+	memberships, err := user.Memberships()
+	if err != nil {
+		out.Print(ui.FormatFailure(failureHeadline, []string{
+			"Failed to check which teams you're already a member of.",
+		}, err))
+		return 1
+	}
+	if len(memberships) > 0 {
+		out.Print(ui.FormatWarning("It's not possible to be in more than one team", nil, nil))
+		return 1
+	}
+	return 0
 }
 
 func requestToJoinTeam(


### PR DESCRIPTION
I _think_ these are the only two ways to create a membership from
the command line. I wonder if I need to also check elsewhere in
the application? For example, what would happen if the user
hacked their `fluidkeys/teams` directory, and duplicated a team
subdirectory?