### PR TITLE
replace team.Parse with team.Load

### DIFF
--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -20,7 +20,6 @@ package fk
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/fluidkeys/fluidkeys/api"
@@ -182,9 +181,9 @@ func processRequestsToJoinTeam() (newTeams []team.Team, returnError error) {
 			continue
 		}
 
-		t, err := team.Parse(strings.NewReader(roster))
+		t, err := team.Load(roster, signature)
 		if err != nil {
-			out.Print(ui.FormatFailure("Failed to parse roster", nil, err))
+			out.Print(ui.FormatFailure("Failed to load team", nil, err))
 			returnError = err
 			continue
 		}

--- a/team/parse.go
+++ b/team/parse.go
@@ -7,8 +7,8 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// Parse parses the team roster's TOML data, returning a Team or an error
-func Parse(r io.Reader) (*Team, error) {
+// parse parses the team roster's TOML data, returning a Team or an error
+func parse(r io.Reader) (*Team, error) {
 	var parsedTeam Team
 	metadata, err := toml.DecodeReader(r, &parsedTeam)
 

--- a/team/parse_test.go
+++ b/team/parse_test.go
@@ -32,7 +32,7 @@ fingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 # missing is_admin
 `
 	reader := strings.NewReader(validRoster)
-	team, err := Parse(reader)
+	team, err := parse(reader)
 
 	assert.NoError(t, err)
 	expectedPeople := []Person{

--- a/team/team.go
+++ b/team/team.go
@@ -153,6 +153,9 @@ func (t *Team) UpdateRoster(signingKey *pgpkey.PgpKey) error {
 // Roster returns the TOML file representing the team roster, and the ASCII armored detached
 // signature of that file.
 func (t Team) Roster() (roster string, signature string) {
+	if t.roster == "" || t.signature == "" {
+		log.Panic("Roster called but roster & signature haven't been set")
+	}
 	return t.roster, t.signature
 }
 

--- a/team/team.go
+++ b/team/team.go
@@ -26,17 +26,27 @@ func LoadTeams(fluidkeysDirectory string) ([]Team, error) {
 		return nil, fmt.Errorf("couldn't get teams directory: %v", err)
 	}
 
-	teamRosters, err := findTeamRosters(teamsDirectory)
+	teamSubdirs, err := findTeamSubdirectories(teamsDirectory)
 	if err != nil {
 		return nil, err
 	}
 
 	teams := []Team{}
-	for _, teamRoster := range teamRosters {
-		log.Printf("loading team roster %s\n", teamRoster)
-		team, err := loadTeamRoster(teamRoster)
+	for _, subdir := range teamSubdirs {
+		log.Printf("loading team roster from %s\n", subdir)
+		roster, err := ioutil.ReadFile(filepath.Join(subdir, rosterFilename))
 		if err != nil {
-			return nil, fmt.Errorf("failed to load %s: %v", teamRoster, err)
+			return nil, fmt.Errorf("failed to read roster from %s: %v", subdir, err)
+		}
+
+		signature, err := ioutil.ReadFile(filepath.Join(subdir, signatureFilename))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read signature from %s: %v", subdir, err)
+		}
+
+		team, err := Load(string(roster), string(signature))
+		if err != nil {
+			return nil, fmt.Errorf("failed to load team from %s: %v", subdir, err)
 		}
 		teams = append(teams, *team)
 	}
@@ -267,48 +277,30 @@ func getTeamDirectory(fluidkeysDirectory string) (directory string, err error) {
 	return teamsDirectory, nil
 }
 
-func findTeamRosters(directory string) ([]string, error) {
-	teamSubdirs, err := ioutil.ReadDir(directory)
+func findTeamSubdirectories(directory string) (teamSubdirs []string, err error) {
+	files, err := ioutil.ReadDir(directory)
 	if err != nil {
 		return nil, err
 	}
 
-	teamRosters := []string{}
-
-	for _, teamSubDir := range teamSubdirs {
-		if !teamSubDir.IsDir() {
+	for _, f := range files {
+		if !f.IsDir() {
 			continue
 		}
 
-		teamRoster := filepath.Join(directory, teamSubDir.Name(), "roster.toml")
-		// TODO: also look for teamRoster.asc and validate the signature
+		teamSubdir := filepath.Join(directory, f.Name())
 
-		if fileExists(teamRoster) {
-			teamRosters = append(teamRosters, teamRoster)
+		rosterPath := filepath.Join(teamSubdir, rosterFilename)
+		signaturePath := filepath.Join(teamSubdir, signatureFilename)
+
+		if fileExists(rosterPath) && fileExists(signaturePath) {
+			teamSubdirs = append(teamSubdirs, teamSubdir)
 		} else {
-			log.Printf("missing %s", teamRoster)
+			log.Printf("ignoring %s (missing one of %s or %s)",
+				teamSubdir, rosterFilename, signatureFilename)
 		}
 	}
-	return teamRosters, nil
-}
-
-func loadTeamRoster(filename string) (*Team, error) {
-	reader, err := os.Open(filename)
-	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %v", filename, err)
-	}
-
-	team, err := Parse(reader)
-	if err != nil {
-		return nil, err
-	}
-
-	err = team.Validate()
-	if err != nil {
-		return nil, fmt.Errorf("error validating team: %v", err)
-	}
-
-	return team, nil
+	return teamSubdirs, nil
 }
 
 func (t Team) subDirectory() string {

--- a/team/team.go
+++ b/team/team.go
@@ -43,6 +43,23 @@ func LoadTeams(fluidkeysDirectory string) ([]Team, error) {
 	return teams, nil
 }
 
+// Load loads a team from the given roster and signature
+func Load(roster string, signature string) (*Team, error) {
+	team, err := parse(strings.NewReader(roster))
+	if err != nil {
+		return nil, err
+	}
+
+	err = team.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("error validating team: %v", err)
+	}
+
+	team.roster = roster
+	team.signature = signature
+	return team, nil
+}
+
 // Directory returns the team subdirectory
 func Directory(t Team, fluidkeysDirectory string) (directory string, err error) {
 	teamDirectory, err := getTeamDirectory(fluidkeysDirectory)

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -28,6 +28,63 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+func TestLoad(t *testing.T) {
+	roster := `# Fluidkeys team roster
+
+uuid = "38be2a70-23d8-11e9-bafd-7f97f2e239a3"
+name = "Fluidkeys CIC"
+
+[[person]]
+email = "paul@fluidkeys.com"
+fingerprint = "B79F 0840 DEF1 2EBB A72F  F72D 7327 A44C 2157 A758"
+is_admin = true
+
+[[person]]
+email = "ian@fluidkeys.com"
+fingerprint = "E63A F0E7 4EB5 DE3F B72D  C981 C991 7093 18EC BDE7"
+is_admin = false
+
+[[person]]
+email = "ray@fluidkeys.com"
+fingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+# missing is_admin
+`
+
+	key, err := pgpkey.LoadFromArmoredEncryptedPrivateKey(
+		exampledata.ExamplePrivateKey4, "test4",
+	)
+	assert.NoError(t, err)
+
+	signature, err := key.MakeArmoredDetachedSignature([]byte(roster))
+
+	team, err := Load(roster, signature)
+
+	assert.NoError(t, err)
+	expectedPeople := []Person{
+		{
+			Email:       "paul@fluidkeys.com",
+			Fingerprint: fpr.MustParse("B79F0840DEF12EBBA72FF72D7327A44C2157A758"),
+			IsAdmin:     true,
+		},
+		{
+			Email:       "ian@fluidkeys.com",
+			Fingerprint: fpr.MustParse("E63AF0E74EB5DE3FB72DC981C991709318ECBDE7"),
+			IsAdmin:     false,
+		},
+		{
+			Email:       "ray@fluidkeys.com",
+			Fingerprint: fpr.MustParse("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+			IsAdmin:     false,
+		},
+	}
+	assert.Equal(t, expectedPeople, team.People)
+
+	assert.Equal(t, uuid.Must(uuid.FromString("38be2a70-23d8-11e9-bafd-7f97f2e239a3")), team.UUID)
+	assert.Equal(t, "Fluidkeys CIC", team.Name)
+	assert.Equal(t, roster, team.roster)
+	assert.Equal(t, signature, team.signature)
+}
+
 func TestRoster(t *testing.T) {
 	t.Run("function simply returns content of roster and signature fields", func(t *testing.T) {
 		testTeam := Team{

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -66,16 +66,16 @@ func TestMembershipFunctions(t *testing.T) {
 		got, err := user.Memberships()
 
 		assert.NoError(t, err)
-		assert.Equal(t, []TeamMembership{
-			{
-				Team: team1,
-				Me:   me1,
-			},
-			{
-				Team: team1,
-				Me:   me2,
-			},
-		}, got)
+
+		if len(got) != 2 {
+			t.Fatalf("expected 2 team memberships, got %d: %v", len(got), got)
+		}
+
+		assert.Equal(t, team1.UUID, got[0].Team.UUID)
+		assert.Equal(t, me1, got[0].Me)
+
+		assert.Equal(t, team1.UUID, got[1].Team.UUID)
+		assert.Equal(t, me2, got[1].Me)
 	})
 
 	t.Run("InTeam", func(t *testing.T) {


### PR DESCRIPTION
the motivation here is to make sure the `Team` struct *always* has `roster` and `signature` set.

Previously, teams loaded through `team.LoadTeams` would *not* have it set, nor would teams loaded
through `team.Parse`

Now, there's a new (tested) function called `team.Load(roster, signature)` which parses the team
*and* then sets signature and roster on the struct. I've unexported `parse` so you can only create
a team through `Load`

* add team.Load(roster, signature) & tests
  this is going to replace `Parse`, but this one passes through the values of
  roster and signature so they're available on the Team struct.

* t.Roster: panic if they're not set. this is a safety check, it shouldn't happen.

* unexport Parse (callers should use Load) instead

* add tests for team.LoadTeams

* refactor team.LoadTeams, test findTeamSubdirectories

* fix tests in user now LoadTeams populates roster