### PR TITLE
block `team create` and `join` if already in team

### DIFF
--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -33,6 +33,10 @@ import (
 )
 
 func teamCreate() exitCode {
+	if code := ensureUserIsntInATeam("Couldn't create team"); code > 0 {
+		return code
+	}
+
 	out.Print("\n")
 
 	out.Print("A Team is a group of people using Fluidkeys together.\n\n")

--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -33,8 +33,20 @@ import (
 )
 
 func teamCreate() exitCode {
-	if code := ensureUserIsntInATeam("Couldn't create team"); code > 0 {
-		return code
+	memberships, err := user.Memberships()
+	if err != nil {
+		out.Print(ui.FormatFailure(
+			"Failed to create team", []string{
+				"Error checking which teams you're already a member of.",
+			}, err))
+		return 1
+	}
+	if len(memberships) > 0 {
+		out.Print(ui.FormatWarning(
+			"Can't create another team", []string{
+				"Currently Fluidkeys only supports being in one team.",
+			}, nil))
+		return 1
 	}
 
 	out.Print("\n")

--- a/fk/teamjoin.go
+++ b/fk/teamjoin.go
@@ -31,6 +31,10 @@ import (
 )
 
 func teamJoin(teamUUID uuid.UUID) exitCode {
+	if code := ensureUserIsntInATeam("Couldn't request to join team"); code > 0 {
+		return code
+	}
+
 	teamName, err := client.GetTeamName(teamUUID)
 	if err != nil {
 		out.Print(ui.FormatFailure("Couldn't request to join team", nil, err))
@@ -88,6 +92,21 @@ func ensureNoExistingRequests(teamUUID uuid.UUID, fingerprint fpr.Fingerprint) e
 			},
 			nil,
 		))
+		return 1
+	}
+	return 0
+}
+
+func ensureUserIsntInATeam(failureHeadline string) exitCode {
+	memberships, err := user.Memberships()
+	if err != nil {
+		out.Print(ui.FormatFailure(failureHeadline, []string{
+			"Failed to check which teams you're already a member of.",
+		}, err))
+		return 1
+	}
+	if len(memberships) > 0 {
+		out.Print(ui.FormatWarning("It's not possible to be in more than one team", nil, nil))
 		return 1
 	}
 	return 0

--- a/fk/teamjoin.go
+++ b/fk/teamjoin.go
@@ -31,8 +31,20 @@ import (
 )
 
 func teamJoin(teamUUID uuid.UUID) exitCode {
-	if code := ensureUserIsntInATeam("Couldn't request to join team"); code > 0 {
-		return code
+	memberships, err := user.Memberships()
+	if err != nil {
+		out.Print(ui.FormatFailure(
+			"Failed to join team", []string{
+				"Error checking which teams you're already a member of.",
+			}, err))
+		return 1
+	}
+	if len(memberships) > 0 {
+		out.Print(ui.FormatWarning(
+			"Can't join another team", []string{
+				"Currently Fluidkeys only supports being in one team.",
+			}, nil))
+		return 1
 	}
 
 	teamName, err := client.GetTeamName(teamUUID)
@@ -92,21 +104,6 @@ func ensureNoExistingRequests(teamUUID uuid.UUID, fingerprint fpr.Fingerprint) e
 			},
 			nil,
 		))
-		return 1
-	}
-	return 0
-}
-
-func ensureUserIsntInATeam(failureHeadline string) exitCode {
-	memberships, err := user.Memberships()
-	if err != nil {
-		out.Print(ui.FormatFailure(failureHeadline, []string{
-			"Failed to check which teams you're already a member of.",
-		}, err))
-		return 1
-	}
-	if len(memberships) > 0 {
-		out.Print(ui.FormatWarning("It's not possible to be in more than one team", nil, nil))
 		return 1
 	}
 	return 0

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -83,11 +83,11 @@ func TestMembershipFunctions(t *testing.T) {
 			gotIsInTeam, gotTeam, err := user.IsInTeam(team1.UUID)
 			assert.NoError(t, err)
 
-			t.Run("returns true", func(t *testing.T) {
+			t.Run("return value of isInTeam should be false", func(t *testing.T) {
 				assert.Equal(t, true, gotIsInTeam)
 			})
 
-			t.Run("returns a pointer to the team", func(t *testing.T) {
+			t.Run("return value of theTeam should be pointer to correct team", func(t *testing.T) {
 				if gotTeam == nil {
 					t.Fatalf("got nil pointer for team")
 				}
@@ -99,11 +99,11 @@ func TestMembershipFunctions(t *testing.T) {
 			gotIsInTeam, gotTeam, err := user.IsInTeam(team2.UUID)
 			assert.NoError(t, err)
 
-			t.Run("returns true", func(t *testing.T) {
+			t.Run("return value of isInTeam should be false", func(t *testing.T) {
 				assert.Equal(t, false, gotIsInTeam)
 			})
 
-			t.Run("returns nil", func(t *testing.T) {
+			t.Run("return value of theTeam should be nil pointer", func(t *testing.T) {
 				if gotTeam != nil {
 					t.Fatalf("expected gotTeam to be nil, but it isn't")
 				}

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -88,7 +88,10 @@ func TestMembershipFunctions(t *testing.T) {
 			})
 
 			t.Run("returns a pointer to the team", func(t *testing.T) {
-				assert.Equal(t, &team1, gotTeam)
+				if gotTeam == nil {
+					t.Fatalf("got nil pointer for team")
+				}
+				assert.Equal(t, team1.UUID, gotTeam.UUID)
 			})
 		})
 


### PR DESCRIPTION
Paul's mod: drop the helper function

I _think_ these are the only two ways to create a membership from the
command line. I wonder if I need to also check elsewhere in the
application? For example, what would happen if the user hacked their
`fluidkeys/teams` directory, and duplicated a team subdirectory?