### PR TITLE
Don't allow LoadTeams to handle > 1 team

### DIFF
--- a/team/team.go
+++ b/team/team.go
@@ -31,6 +31,14 @@ func LoadTeams(fluidkeysDirectory string) ([]Team, error) {
 		return nil, err
 	}
 
+	if len(teamSubdirs) > 1 {
+		return nil, fmt.Errorf(
+			"fluidkeys currently only supports one team, %d team subdirectorys found in %s",
+			len(teamSubdirs),
+			teamsDirectory,
+		)
+	}
+
 	teams := []Team{}
 	for _, subdir := range teamSubdirs {
 		log.Printf("loading team roster from %s\n", subdir)


### PR DESCRIPTION
This is a temporary guard, that we should remove when we make Fluidkeys support multiple teams.

Here's an example of how the error looks 'in the wild' (I hacked my teams subdir to produce it):

![Screenshot 2019-03-20 at 15 37 17](https://user-images.githubusercontent.com/55195/54697978-6c571e80-4b26-11e9-8c95-538397a0a0c2.png)
