### PR TITLE
scheduler: add tests, fix bug

### DIFF
--- a/fk/main.go
+++ b/fk/main.go
@@ -153,7 +153,7 @@ func ensureCrontabStateMatchesConfig() {
 
 			out.Print("To fix this, run " + colour.Cmd("crontab -e") + " and add these lines:\n\n")
 			out.Print(formatFileDivider("crontab", 80))
-			out.Print(scheduler.CronLines)
+			out.Print("\n" + scheduler.CronLines)
 			out.Print(formatFileDivider("", 80))
 			out.Print("\n\n")
 
@@ -178,7 +178,7 @@ func ensureCrontabStateMatchesConfig() {
 
 			out.Print("To fix this, run " + colour.Cmd("crontab -e") + " and remove these lines:\n\n")
 			out.Print(formatFileDivider("crontab", 80))
-			out.Print(scheduler.CronLines)
+			out.Print("\n" + scheduler.CronLines)
 			out.Print(formatFileDivider("", 80))
 			out.Print("\n\n")
 		}


### PR DESCRIPTION
before I start proper work on this, fix the bug that meant cron lines
weren't being removed:

https://trello.com/c/Tb2dSSEE

the problem was that we were relying on our cron lines having a trailing
(and leading) newline to be able to detect or remove them. Now the cron
lines can exist any (valid) way in the crontab.

Also improve the appearance of adding crontab lines:

before: "" after: ""# Fluidkeys...\n@hourly...\n"

before: "# some other stuff" after: "# some other stuff\n\n"#
Fluidkeys...\n@hourly...\n"

before: "# some other stuff\n" after: "# some other stuff\n\n"#
Fluidkeys...\n@hourly...\n"