### PR TITLE
Add db.RecordLast and GetLast

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
+	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/fluidkeys/fluidkeys/team"
 	"github.com/gofrs/uuid"
 )
@@ -41,6 +42,7 @@ type Database struct {
 type Message struct {
 	KeysImportedIntoGnuPG []KeyImportedIntoGnuPGMessage
 	RequestsToJoinTeams   []RequestToJoinTeamMessage
+	LastUpdated           map[string]time.Time
 }
 
 // KeyImportedIntoGnuPGMessage represents a key the user has imported into GnuPG from Fluidkeys
@@ -103,6 +105,48 @@ func (db *Database) RecordRequestToJoinTeam(
 	)
 
 	return db.saveToFile(*message)
+}
+
+// RecordUpdated takes an item and records in the database that it's been updated.
+func (db *Database) RecordUpdated(item interface{}, now time.Time) error {
+	message, err := db.loadFromFile()
+	if err != nil {
+		return err
+	}
+
+	switch i := item.(type) {
+	case *pgpkey.PgpKey:
+		message.LastUpdated["Key:"+i.Fingerprint().Uri()] = now
+	case pgpkey.PgpKey:
+		message.LastUpdated["Key:"+i.Fingerprint().Uri()] = now
+	case *fpr.Fingerprint:
+		message.LastUpdated["Key:"+i.Uri()] = now
+	case fpr.Fingerprint:
+		message.LastUpdated["Key:"+i.Uri()] = now
+	}
+
+	return db.saveToFile(*message)
+}
+
+// GetLastUpdated takes an item and returns the last time it was recorded as being updated.
+func (db *Database) GetLastUpdated(item interface{}) (lastUpdated time.Time, err error) {
+	message, err := db.loadFromFile()
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	switch i := item.(type) {
+	case *pgpkey.PgpKey:
+		return message.LastUpdated["Key:"+i.Fingerprint().Uri()], nil
+	case pgpkey.PgpKey:
+		return message.LastUpdated["Key:"+i.Fingerprint().Uri()], nil
+	case *fpr.Fingerprint:
+		return message.LastUpdated["Key:"+i.Uri()], nil
+	case fpr.Fingerprint:
+		return message.LastUpdated["Key:"+i.Uri()], nil
+	}
+
+	return time.Time{}, fmt.Errorf("no record of when %v was last updated", item)
 }
 
 // GetFingerprintsImportedIntoGnuPG returns a slice of fingerprints that have
@@ -196,7 +240,9 @@ func (db *Database) loadFromFile() (message *Message, err error) {
 	file, err := os.Open(db.jsonFilename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &Message{}, nil
+			return &Message{
+				LastUpdated: map[string]time.Time{},
+			}, nil
 		}
 		return nil, fmt.Errorf("couldn't open '%s': %v", db.jsonFilename, err)
 	}
@@ -215,6 +261,7 @@ func (db *Database) loadFromFile() (message *Message, err error) {
 			message.KeysImportedIntoGnuPG,
 		),
 		RequestsToJoinTeams: message.RequestsToJoinTeams,
+		LastUpdated:         message.LastUpdated,
 	}, nil
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -256,6 +256,10 @@ func (db *Database) loadFromFile() (message *Message, err error) {
 		return nil, fmt.Errorf("error loading json: %v", err)
 	}
 
+	if len(message.LastUpdated) == 0 {
+		message.LastUpdated = make(map[string]time.Time)
+	}
+
 	return &Message{
 		KeysImportedIntoGnuPG: deduplicateKeyImportedIntoGnuPGMessages(
 			message.KeysImportedIntoGnuPG,

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,12 +1,16 @@
 package database
 
 import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/fluidkeys/fluidkeys/assert"
 	"github.com/fluidkeys/fluidkeys/exampledata"
 	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
+	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/fluidkeys/fluidkeys/team"
 	"github.com/fluidkeys/fluidkeys/testhelpers"
 	"github.com/gofrs/uuid"
@@ -342,6 +346,81 @@ func TestGetExistingRequestToJoinTeam(t *testing.T) {
 			t.Fatalf("expected gotRequest to be nil, but it isn't")
 		}
 	})
+}
+
+func TestUpdated(t *testing.T) {
+	now := time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
+	later := now.Add(time.Duration(6) * time.Hour)
+
+	t.Run("fingerprints", func(t *testing.T) {
+		database := New(testhelpers.Maketemp(t))
+
+		fingerprint := exampledata.ExampleFingerprint2
+
+		t.Run("record to an empty database", func(t *testing.T) {
+			err := database.RecordUpdated(fingerprint, now)
+			assert.NoError(t, err)
+		})
+
+		t.Run("can get last updated time", func(t *testing.T) {
+			got, err := database.GetLastUpdated(fingerprint)
+			assert.NoError(t, err)
+			assert.Equal(t, now, got)
+		})
+
+		t.Run("pointers and values are handled the same", func(t *testing.T) {
+			got, err := database.GetLastUpdated(&fingerprint)
+			assert.NoError(t, err)
+			assert.Equal(t, now, got)
+		})
+
+		t.Run("record updates the previously time", func(t *testing.T) {
+			err := database.RecordUpdated(fingerprint, later)
+			assert.NoError(t, err)
+
+			got, err := database.GetLastUpdated(fingerprint)
+			assert.NoError(t, err)
+			assert.Equal(t, later, got)
+		})
+
+		t.Run("a second value records it's own time", func(t *testing.T) {
+			fingerprint2 := exampledata.ExampleFingerprint3
+			now := time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
+
+			err := database.RecordUpdated(fingerprint2, now)
+			assert.NoError(t, err)
+
+			got, err := database.GetLastUpdated(fingerprint)
+			assert.NoError(t, err)
+			assert.Equal(t, later, got)
+
+			got, err = database.GetLastUpdated(fingerprint2)
+			assert.NoError(t, err)
+			assert.Equal(t, now, got)
+		})
+
+		t.Run("keys are handled the same", func(t *testing.T) {
+			err := database.RecordUpdated(fingerprint, now)
+
+			key, err := pgpkey.LoadFromArmoredPublicKey(exampledata.ExamplePublicKey2)
+			assert.NoError(t, err)
+			err = database.RecordUpdated(key, later)
+			assert.NoError(t, err)
+
+			got, err := database.GetLastUpdated(fingerprint)
+			assert.NoError(t, err)
+			assert.Equal(t, later, got)
+		})
+
+	})
+
+	t.Run("unrecognised objects return error", func(t *testing.T) {
+		database := New(testhelpers.Maketemp(t))
+
+		_, err := database.GetLastUpdated("foo")
+		assert.Equal(t, fmt.Errorf("no record of when foo was last updated"), err)
+	})
+
 }
 
 func TestDeduplicateKeyImportedIntoGnuPGMessages(t *testing.T) {


### PR DESCRIPTION
These functions can be used to record when certain things get updated. They take an interface, but currently we only handle keys and fingerprints which are treated as the same.

Don't panic if "LastUpdated" doesn't exist in json