### PR TITLE
add PgpKey.CertifyEmail()

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,7 +34,7 @@
   revision = "c8a726146d32ad8367208303b76774147d749ffe"
 
 [[projects]]
-  digest = "1:ace3142d1c330736b91b01355276568b90431cedf4d9469798568ef2ba1d64f5"
+  digest = "1:1b08965cbe0b8ebd251bd448a08df2b70a0a5bbfb35e59985d6c7f5a04cbc4ec"
   name = "github.com/fluidkeys/crypto"
   packages = [
     "cast5",
@@ -47,7 +47,7 @@
     "openpgp/s2k",
   ]
   pruneopts = "UT"
-  revision = "2018-09-13"
+  revision = "d1eb919c5d7a79d47db3bed84c8637648a60ab27"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,8 +29,8 @@
   name = "github.com/sethvargo/go-diceware"
 
 [[constraint]]
-  revision = "2018-09-13"
   name = "github.com/fluidkeys/crypto"
+  revision = "d1eb919c5d7a79d47db3bed84c8637648a60ab27"
 
 [[constraint]]
   branch = "master"

--- a/pgpkey/certify.go
+++ b/pgpkey/certify.go
@@ -1,0 +1,85 @@
+package pgpkey
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/fluidkeys/crypto/openpgp/packet"
+	"github.com/fluidkeys/fluidkeys/policy"
+)
+
+// CertifyEmail finds user IDs which match the given email, and creates a certification
+// signature using the unlocked key certifier.
+func (p *PgpKey) CertifyEmail(email string, certifier *PgpKey, now time.Time) error {
+	if p.PrimaryKey.KeyId == certifier.PrimaryKey.KeyId {
+		return fmt.Errorf("key and certifier key are the same")
+	}
+	uids := identitiesMatchingEmail(p, email)
+	if len(uids) == 0 {
+		return fmt.Errorf("no identities match that email")
+	}
+
+	for _, userid := range uids {
+		identity, ok := p.Identities[userid]
+		if !ok {
+			log.Panic(fmt.Sprintf("Identities[\"%s\"] does not exist", userid))
+		}
+
+		if certifier.PrivateKey == nil {
+			return fmt.Errorf("signer must have PrivateKey")
+		}
+
+		config := packet.Config{
+			DefaultHash: policy.SignatureHashFunction,
+		}
+
+		// Adapted from p.SignIdentity(userid, &signer.Entity, &config)
+		exportable := false
+		sig := &packet.Signature{
+			CreationTime:            now,
+			SigType:                 packet.SigTypeGenericCert,
+			PubKeyAlgo:              certifier.PrivateKey.PubKeyAlgo,
+			Hash:                    config.Hash(),
+			IssuerKeyId:             &certifier.PrivateKey.KeyId,
+			ExportableCertification: &exportable,
+		}
+
+		err := sig.SignUserId(userid, p.PrimaryKey, certifier.PrivateKey, &config)
+		if err != nil {
+			return err
+		}
+
+		newSigs := []*packet.Signature{}
+		for _, existingSig := range identity.Signatures {
+			if existingSig.SigType == sig.SigType && existingSig.IssuerKeyId == sig.IssuerKeyId {
+				// drop this existing signature: the new one replaces it
+				continue
+			}
+			newSigs = append(newSigs, existingSig)
+		}
+
+		newSigs = append(newSigs, sig)
+
+		identity.Signatures = newSigs
+	}
+	return nil
+}
+
+func identitiesMatchingEmail(key *PgpKey, email string) (uids []string) {
+	for _, identity := range key.Identities {
+		if matches(identity.UserId.Email, email) {
+			uids = append(uids, identity.Name)
+		}
+	}
+	return uids
+}
+
+// matches performs a relaxed comparison of 2 email addresses, since the context in which it's used
+// is on an existing key. We allow JOHNDOE@example.com to match equal to johndoe@example.com where
+// in other contexts we probably wouldn't (e.g. doing a global key discovery, where those two
+// mail names could actually be different :\
+func matches(email1 string, email2 string) bool {
+	return strings.ToLower(email1) == strings.ToLower(email2)
+}

--- a/pgpkey/certify_test.go
+++ b/pgpkey/certify_test.go
@@ -1,0 +1,117 @@
+package pgpkey
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fluidkeys/crypto/openpgp/packet"
+	"github.com/fluidkeys/fluidkeys/assert"
+	"github.com/fluidkeys/fluidkeys/exampledata"
+	"github.com/fluidkeys/fluidkeys/policy"
+)
+
+func TestCertifyEmail(t *testing.T) {
+	now := time.Date(2019, 6, 15, 16, 35, 14, 0, time.UTC)
+	later := now.Add(time.Duration(10) * time.Minute)
+
+	certifier, err := LoadFromArmoredEncryptedPrivateKey(exampledata.ExamplePrivateKey4, "test4")
+	assert.NoError(t, err)
+
+	t.Run("matching email", func(t *testing.T) {
+		keyToCertify, err := LoadFromArmoredPublicKey(exampledata.ExamplePublicKey2)
+		assert.NoError(t, err)
+
+		err = keyToCertify.CertifyEmail("test2@example.com", certifier, now)
+		assert.NoError(t, err)
+
+		gotSigs := getSigsForIdentity(t, keyToCertify, "<test2@example.com>")
+		assert.Equal(t, 1, len(gotSigs))
+
+		gotSig := gotSigs[0]
+
+		t.Run("exportable certification is false", func(t *testing.T) {
+			if gotSig.ExportableCertification == nil {
+				t.Fatalf("sig.ExportableCertification is nil (should be false)")
+			} else if *gotSig.ExportableCertification == true {
+				t.Fatalf("sig.ExportableCertification is true (should be false)")
+			}
+		})
+
+		t.Run("hash function used matches policy", func(t *testing.T) {
+			assert.Equal(t, gotSig.Hash, policy.SignatureHashFunction)
+		})
+
+		t.Run("signature verifies", func(t *testing.T) {
+			// err = e.PrimaryKey.VerifyUserIdSignature(pkt.Id, e.PrimaryKey, sig); err != nil
+			assert.NoError(t,
+				certifier.PrimaryKey.VerifyUserIdSignature(
+					"<test2@example.com>",
+					keyToCertify.PrimaryKey,
+					gotSig,
+				),
+			)
+		})
+	})
+
+	t.Run("returns error if trying to certify own key", func(t *testing.T) {
+		err = certifier.CertifyEmail("test2@example.com", certifier, now)
+		assert.Equal(t, fmt.Errorf("key and certifier key are the same"), err)
+	})
+
+	t.Run("returns error if no identities match", func(t *testing.T) {
+		keyToCertify, err := LoadFromArmoredPublicKey(exampledata.ExamplePublicKey2)
+		assert.NoError(t, err)
+
+		err = keyToCertify.CertifyEmail("nomatch@example.com", certifier, now)
+		assert.Equal(t, fmt.Errorf("no identities match that email"), err)
+	})
+
+	t.Run("returns error if missing certifier private key", func(t *testing.T) {
+		keyToCertify, err := LoadFromArmoredPublicKey(exampledata.ExamplePublicKey2)
+		assert.NoError(t, err)
+
+		publicKeyCertifier, err := LoadFromArmoredPublicKey(exampledata.ExamplePublicKey3)
+		assert.NoError(t, err)
+
+		err = keyToCertify.CertifyEmail("test2@example.com", publicKeyCertifier, now)
+		assert.Equal(t, fmt.Errorf("signer must have PrivateKey"), err)
+	})
+
+	t.Run("returns error if locked certifier private key", func(t *testing.T) {
+		// TODO: work out how to make a locked private key
+
+		// keyToCertify, err := LoadFromArmoredPublicKey(exampledata.ExamplePublicKey2)
+		// assert.NoError(t, err)
+		// lockedCertifier, err := LoadFromArmoredEncryptedPrivateKey(exampledata.ExamplePrivateKey4, "test4")
+		// assert.NoError(t, err)
+		// err = keyToCertify.CertifyEmail("test2@example.com", publicKeyCertifier, now)
+		// assert.Equal(t, fmt.Errorf("foo"), err)
+	})
+
+	t.Run("replaces existing certification from same certifier", func(t *testing.T) {
+		keyToCertify, err := LoadFromArmoredPublicKey(exampledata.ExamplePublicKey2)
+		assert.NoError(t, err)
+
+		err = keyToCertify.CertifyEmail("test2@example.com", certifier, now)
+		assert.NoError(t, err)
+
+		err = keyToCertify.CertifyEmail("test2@example.com", certifier, later)
+		assert.NoError(t, err)
+
+		gotSigs := getSigsForIdentity(t, keyToCertify, "<test2@example.com>")
+		assert.Equal(t, 1, len(gotSigs))
+
+		assert.Equal(t, later, gotSigs[0].CreationTime)
+	})
+
+}
+
+func getSigsForIdentity(t *testing.T, k *PgpKey, uid string) (signatures []*packet.Signature) {
+	identity, ok := k.Identities[uid]
+	if !ok {
+		return nil
+	}
+
+	return identity.Signatures
+}


### PR DESCRIPTION
can't merge before https://github.com/fluidkeys/crypto/pull/10

this creates non-exportable (local only) certification signatures of keys.
when imported into GnuPG, it shows those keys as valid / trusted.