### PR TITLE
team fetch: simplify

### DIFF
--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -42,7 +42,8 @@ func teamFetch() exitCode {
 
 	myMemberships, err := user.Memberships()
 	if err != nil {
-		log.Panic(err)
+		out.Print(ui.FormatFailure("Failed to list teams", nil, err))
+		return 1
 	}
 
 	for i := range myMemberships {

--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -35,14 +35,14 @@ import (
 func teamFetch() exitCode {
 	sawError := false
 
-	myTeams, err := user.Memberships()
+	myMemberships, err := user.Memberships()
 	if err != nil {
 		log.Panic(err)
 	}
 
-	for i := range myTeams {
-		var myTeam *team.Team = &myTeams[i].Team // allows us move myTeam to point at updated team
-		me := myTeams[i].Me
+	for i := range myMemberships {
+		var myTeam *team.Team = &myMemberships[i].Team // allows us move pointer to updated team
+		me := myMemberships[i].Me
 
 		printHeader(myTeam.Name)
 


### PR DESCRIPTION
previously we were handling new and updated teams separately (2 places to fetch keys, etc)

this PR simplifies it so we always do:

1. handle requests to join teams
2. load our teams (including those from 1.) and update them