### PR TITLE
trust our own keys when we push them back into gpg

### DIFF
--- a/fk/privatekeys.go
+++ b/fk/privatekeys.go
@@ -81,5 +81,10 @@ func pushPrivateKeyBackToGpg(
 		return err
 	}
 
-	return gpg.ImportArmoredKey(armoredPrivateKey)
+	err = gpg.ImportArmoredKey(armoredPrivateKey)
+	if err != nil {
+		return err
+	}
+
+	return gpg.TrustUltimately(key.Fingerprint())
 }

--- a/gpgwrapper/interfaces.go
+++ b/gpgwrapper/interfaces.go
@@ -21,20 +21,9 @@ import (
 	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 )
 
-// ExportPrivateKeyInterface is the interface that wraps the ExportPrivateKey
-// method.
-//
-// ExportPrivateKey returns 1 ascii armored private key for the given
-// fingerprint, assuming it is encrypted with the given password.
-// The outputted private key is encrypted with the password.
-type ExportPrivateKeyInterface interface {
-	ExportPrivateKey(fingerprint fpr.Fingerprint, password string) (string, error)
-}
-
-// ImportArmoredKeyInterface is the interface that wraps the ExportPrivateKey
-// ImportArmoredKey.
-//
-// ImportArmoredKey imports the given armored key into the GPG key ring
-type ImportArmoredKeyInterface interface {
+// GnuPGInterface allows mocking out GnuPG for testing
+type GnuPGInterface interface {
 	ImportArmoredKey(string) error
+	ExportPrivateKey(fingerprint fpr.Fingerprint, password string) (string, error)
+	TrustUltimately(fpr.Fingerprint) error
 }

--- a/pgpkey/interfaces.go
+++ b/pgpkey/interfaces.go
@@ -17,23 +17,17 @@
 
 package pgpkey
 
-// LoadFromArmoredEncryptedPrivateKeyInterface provides and interface to the
-// LoadFromArmoredEncryptedPrivateKey method
-//
-// LoadFromArmoredEncryptedPrivateKey takes an encrypted, asci armored
-// private key and a password and returns a pointer to a PgpKey with:
-//
-// * a decrypted PrivateKey.
-// * all subkeys decrypted
-type LoadFromArmoredEncryptedPrivateKeyInterface interface {
+import "github.com/fluidkeys/fluidkeys/fingerprint"
+
+// LoaderInterface allows mocking Loader (not PgpKey) which itself wraps the package function
+// pgpkey.LoadFromArmoredEncryptedPrivateKey
+type LoaderInterface interface {
 	LoadFromArmoredEncryptedPrivateKey(string, string) (*PgpKey, error)
 }
 
-// ArmorInterface is the interface to the Armor and ArmorPrivate methods.
-//
-// Armor returns the public part of a key in armored format.
-// ArmorPrivate returns the private part of a key in armored format.
-type ArmorInterface interface {
+// PgpKeyInterface allows mocking PgpKey
+type PgpKeyInterface interface {
 	Armor() (string, error)
 	ArmorPrivate(string) (string, error)
+	Fingerprint() fingerprint.Fingerprint
 }


### PR DESCRIPTION
use the new GnuPG.TrustUltimately method to configure GnuPG's ownertrust
database that we should trust our own signatures on other peoples' keys.