### PR TITLE
`fk status`: Print keys and team members for memberships

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -115,6 +115,10 @@ func (db *Database) RecordLast(verb string, item interface{}, now time.Time) err
 		return err
 	}
 
+	if verb == "" {
+		return fmt.Errorf("verb can't be empty")
+	}
+
 	switch i := item.(type) {
 	case *pgpkey.PgpKey:
 		message.EventTimes[verb+":"+keyItem+":"+i.Fingerprint().Uri()] = now
@@ -128,6 +132,8 @@ func (db *Database) RecordLast(verb string, item interface{}, now time.Time) err
 		message.EventTimes[verb+":"+teamItem+":"+i.UUID.String()] = now
 	case team.Team:
 		message.EventTimes[verb+":"+teamItem+":"+i.UUID.String()] = now
+	default:
+		return fmt.Errorf("don't know how to handle %v", item)
 	}
 
 	return db.saveToFile(*message)

--- a/fk/main.go
+++ b/fk/main.go
@@ -319,6 +319,7 @@ func keyList() exitCode {
 	}
 
 	out.Print(table.FormatKeyTable(keysWithWarnings))
+	out.Print(table.FormatKeyTablePrimaryInstruction(keysWithWarnings))
 	return 0
 }
 

--- a/fk/main.go
+++ b/fk/main.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 
 	"github.com/fluidkeys/fluidkeys/emailutils"
-	"github.com/fluidkeys/fluidkeys/keytable"
 	"github.com/fluidkeys/fluidkeys/status"
+	"github.com/fluidkeys/fluidkeys/table"
 
 	"github.com/fluidkeys/fluidkeys/api"
 	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
@@ -306,19 +306,19 @@ func keyList() exitCode {
 
 	out.Print("\n")
 
-	keysWithWarnings := []keytable.KeyWithWarnings{}
+	keysWithWarnings := []table.KeyWithWarnings{}
 
 	for i := range keys {
 		key := &keys[i]
 
-		keyWithWarnings := keytable.KeyWithWarnings{
+		keyWithWarnings := table.KeyWithWarnings{
 			Key:      key,
 			Warnings: status.GetKeyWarnings(*key, &Config),
 		}
 		keysWithWarnings = append(keysWithWarnings, keyWithWarnings)
 	}
 
-	out.Print(keytable.Format(keysWithWarnings))
+	out.Print(table.FormatKeyTable(keysWithWarnings))
 	return 0
 }
 

--- a/fk/main.go
+++ b/fk/main.go
@@ -73,6 +73,7 @@ Usage:
 	fk team join <uuid>
 	fk team authorize
 	fk team fetch [--cron-output]
+	fk status
 	fk secret send <recipient-email>
 	fk secret send [<filename>] --to=<email>
 	fk secret receive
@@ -108,7 +109,7 @@ Options:
 	}
 	var code exitCode
 
-	switch getSubcommand(args, []string{"key", "secret", "team", "setup", "sync"}) {
+	switch getSubcommand(args, []string{"key", "secret", "team", "setup", "sync", "status"}) {
 	case "key":
 		code = keySubcommand(args)
 
@@ -123,6 +124,10 @@ Options:
 
 	case "team":
 		code = teamSubcommand(args)
+
+	case "status":
+		code = statusSubcommand(args)
+
 	default:
 		out.Print("unhandled subcommand")
 		code = 1

--- a/fk/status.go
+++ b/fk/status.go
@@ -50,6 +50,13 @@ func statusSubcommand(args docopt.Opts) exitCode {
 		for _, membership := range groupedMembership.Memberships {
 			key, err := loadPgpKey(membership.Me.Fingerprint)
 			if err != nil {
+				out.Print(ui.FormatFailure(
+					"Failed to load key associated with team "+membership.Team.Name,
+					[]string{
+						"Tried to load key " + membership.Me.Fingerprint.Hex(),
+					},
+					err,
+				))
 				return 1
 			}
 

--- a/fk/status.go
+++ b/fk/status.go
@@ -18,7 +18,6 @@
 package fk
 
 import (
-	"log"
 	"time"
 
 	docopt "github.com/docopt/docopt-go"
@@ -35,7 +34,8 @@ func statusSubcommand(args docopt.Opts) exitCode {
 
 	groupedMemberships, err := user.GroupedMemberships()
 	if err != nil {
-		log.Panic(err)
+		out.Print(ui.FormatFailure("Failed to load team memberships", nil, err))
+		return 1
 	}
 
 	allKeysWithWarnings := []table.KeyWithWarnings{}

--- a/fk/status.go
+++ b/fk/status.go
@@ -37,6 +37,8 @@ func statusSubcommand(args docopt.Opts) exitCode {
 		log.Panic(err)
 	}
 
+	allKeysWithWarnings := []table.KeyWithWarnings{}
+
 	for _, groupedMembership := range groupedMemberships {
 		printHeader(groupedMembership.Team.Name)
 
@@ -56,6 +58,7 @@ func statusSubcommand(args docopt.Opts) exitCode {
 			}
 
 			teamKeysWithWarnings = append(teamKeysWithWarnings, keyWithWarnings)
+			allKeysWithWarnings = append(allKeysWithWarnings, keyWithWarnings)
 			if membership.Me.IsAdmin {
 				adminOfTeam = true
 			}
@@ -87,6 +90,8 @@ func statusSubcommand(args docopt.Opts) exitCode {
 		}
 
 		out.Print("To fetch and store team members keys run " + colour.Cmd("fk team fetch") + "\n\n")
+
+		out.Print(table.FormatKeyTablePrimaryInstruction(allKeysWithWarnings))
 	}
 
 	return 0

--- a/fk/status.go
+++ b/fk/status.go
@@ -85,6 +85,8 @@ func statusSubcommand(args docopt.Opts) exitCode {
 				colour.Cmd("fk team join " + groupedMembership.Team.UUID.String()),
 			}))
 		}
+
+		out.Print("To fetch and store team members keys run " + colour.Cmd("fk team fetch") + "\n\n")
 	}
 
 	return 0

--- a/fk/status.go
+++ b/fk/status.go
@@ -105,7 +105,8 @@ func statusSubcommand(args docopt.Opts) exitCode {
 			}))
 		}
 
-		out.Print("To fetch and store team members keys run " + colour.Cmd("fk team fetch") + "\n\n")
+		out.Print("Team keys are updated automatically. To check for updates now, run " +
+			colour.Cmd("fk team fetch") + "\n\n")
 
 		out.Print(table.FormatKeyTablePrimaryInstruction(allKeysWithWarnings))
 	}

--- a/fk/status.go
+++ b/fk/status.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package fk
+
+import (
+	docopt "github.com/docopt/docopt-go"
+)
+
+func statusSubcommand(args docopt.Opts) exitCode {
+
+	return 0
+}

--- a/fk/status.go
+++ b/fk/status.go
@@ -22,9 +22,11 @@ import (
 	"time"
 
 	docopt "github.com/docopt/docopt-go"
+	"github.com/fluidkeys/fluidkeys/colour"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/status"
 	"github.com/fluidkeys/fluidkeys/table"
+	"github.com/fluidkeys/fluidkeys/ui"
 )
 
 func statusSubcommand(args docopt.Opts) exitCode {
@@ -37,6 +39,9 @@ func statusSubcommand(args docopt.Opts) exitCode {
 
 	for _, groupedMembership := range groupedMemberships {
 		printHeader(groupedMembership.Team.Name)
+
+		adminOfTeam := false
+
 		teamKeysWithWarnings := []table.KeyWithWarnings{}
 
 		for _, membership := range groupedMembership.Memberships {
@@ -51,7 +56,9 @@ func statusSubcommand(args docopt.Opts) exitCode {
 			}
 
 			teamKeysWithWarnings = append(teamKeysWithWarnings, keyWithWarnings)
-
+			if membership.Me.IsAdmin {
+				adminOfTeam = true
+			}
 		}
 		out.Print(table.FormatKeyTable(teamKeysWithWarnings))
 
@@ -71,6 +78,13 @@ func statusSubcommand(args docopt.Opts) exitCode {
 		}
 
 		out.Print(table.FormatPeopleTable(peopleRows))
+
+		if adminOfTeam {
+			out.Print(ui.FormatInfo("Invite others to join the team", []string{
+				"Your team members can request to join the team by running",
+				colour.Cmd("fk team join " + groupedMembership.Team.UUID.String()),
+			}))
+		}
 	}
 
 	return 0

--- a/fk/status.go
+++ b/fk/status.go
@@ -23,6 +23,7 @@ import (
 
 	docopt "github.com/docopt/docopt-go"
 	"github.com/fluidkeys/fluidkeys/colour"
+	"github.com/fluidkeys/fluidkeys/humanize"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/status"
 	"github.com/fluidkeys/fluidkeys/table"
@@ -71,11 +72,19 @@ func statusSubcommand(args docopt.Opts) exitCode {
 			if err != nil {
 				continue
 			}
+			var roughDurationSinceLastFetched string
+			if lastFetched.IsZero() {
+				roughDurationSinceLastFetched = "Never"
+			} else {
+				roughDurationSinceLastFetched = humanize.RoughDuration(
+					time.Since(lastFetched),
+				) + " ago"
+			}
 			peopleRows = append(
 				peopleRows, table.PersonRow{
 					Email:              person.Email,
 					IsAdmin:            person.IsAdmin,
-					TimeSinceLastFetch: time.Since(lastFetched),
+					TimeSinceLastFetch: roughDurationSinceLastFetched,
 				},
 			)
 		}

--- a/fk/status.go
+++ b/fk/status.go
@@ -81,7 +81,7 @@ func statusSubcommand(args docopt.Opts) exitCode {
 			}
 			var roughDurationSinceLastFetched string
 			if lastFetched.IsZero() {
-				roughDurationSinceLastFetched = "Never"
+				roughDurationSinceLastFetched = "-"
 			} else {
 				roughDurationSinceLastFetched = humanize.RoughDuration(
 					time.Since(lastFetched),

--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -178,6 +178,8 @@ func fetchAndSignTeamKeys(t team.Team, me team.Person, unlockedKey *pgpkey.PgpKe
 				log.Print(err)
 				return fmt.Errorf("Failed to import key into gpg")
 			}
+			db.RecordLast("fetch", key.Fingerprint(), time.Now())
+
 			return nil
 		})
 		// keep trying subsequent keys even if we hit an error.
@@ -306,6 +308,7 @@ func getUnlockedKey(fingerprint fp.Fingerprint, unattended bool) (*pgpkey.PgpKey
 	if err != nil {
 		return nil, err
 	}
+
 	return unlockedKey, nil
 }
 

--- a/table/keytable_test.go
+++ b/table/keytable_test.go
@@ -1,4 +1,21 @@
-package keytable
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package table
 
 import (
 	"testing"
@@ -48,52 +65,6 @@ func TestMakeRowsFromColumns(t *testing.T) {
 	}
 
 	AssertEqualCells(t, want, got)
-}
-
-func TestMakeStringsFromRows(t *testing.T) {
-	t.Run("with unformatted strings", func(t *testing.T) {
-		rows := []row{
-			row{"Name", "Age", "Location"},
-			row{divider, divider, divider},
-			row{"Gillian", "45", ""},
-			row{divider, divider, divider},
-			row{"Jill", "76", "Sheffield"},
-			row{divider, divider, divider},
-			row{"", "23", ""},
-			row{"", "12", ""},
-		}
-
-		got := makeStringsFromRows(rows)
-		want := []string{
-			"Name     Age  Location ",
-			"───────  ───  ─────────",
-			"Gillian  45            ",
-			"───────  ───  ─────────",
-			"Jill     76   Sheffield",
-			"───────  ───  ─────────",
-			"         23            ",
-			"         12            ",
-		}
-
-		assert.AssertEqualSliceOfStrings(t, want, got)
-	})
-
-	t.Run("with coloured strings", func(t *testing.T) {
-		rows := []row{
-			row{colour.TableHeader("Name"), colour.TableHeader("Age")},
-			row{divider, divider},
-			row{"Gillian", "45"},
-		}
-
-		got := makeStringsFromRows(rows)
-		want := []string{
-			colour.TableHeader("Name") + "     " + colour.TableHeader("Age"),
-			"───────  ───",
-			"Gillian  45 ",
-		}
-
-		assert.AssertEqualSliceOfStrings(t, want, got)
-	})
 }
 
 func TestGetColumnWidths(t *testing.T) {

--- a/table/peopletable.go
+++ b/table/peopletable.go
@@ -47,7 +47,7 @@ func makePeopleTableRows(peopleRows []PersonRow) (rows []row) {
 		rows = append(rows, []string{
 			peopleRow.Email,
 			peopleRow.TimeSinceLastFetch,
-			printAdminIfTrue(peopleRow.IsAdmin),
+			returnAdminIfTrue(peopleRow.IsAdmin),
 		})
 		rows = append(rows, placeholderDividerRow)
 	}
@@ -60,7 +60,7 @@ var peopleHeader = row{
 	colour.TableHeader(""),
 }
 
-func printAdminIfTrue(status bool) string {
+func returnAdminIfTrue(status bool) string {
 	if status {
 		return "admin"
 	}

--- a/table/peopletable.go
+++ b/table/peopletable.go
@@ -62,7 +62,7 @@ var peopleHeader = row{
 
 func printAdminIfTrue(status bool) string {
 	if status {
-		return "Admin"
+		return "admin"
 	}
 	return ""
 }

--- a/table/peopletable.go
+++ b/table/peopletable.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package table
+
+import (
+	"time"
+
+	"github.com/fluidkeys/fluidkeys/humanize"
+
+	"github.com/fluidkeys/fluidkeys/colour"
+)
+
+// A PersonRow is used to format a row in the table
+type PersonRow struct {
+	Email              string
+	TimeSinceLastFetch time.Duration
+	IsAdmin            bool
+}
+
+// FormatPeopleTable takes a slice of people rows and returns a string containing a formatted table.
+func FormatPeopleTable(peopleRows []PersonRow) (output string) {
+	personRows := makePeopleTableRows(peopleRows)
+	rowStrings := formatTableStringsFromRows(personRows)
+	for _, rowString := range rowStrings {
+		output += rowString + "\n"
+	}
+	return output + "\n"
+}
+
+func makePeopleTableRows(peopleRows []PersonRow) (rows []row) {
+	placeholderDividerRow := row{divider, divider, divider}
+
+	rows = append(rows, peopleHeader)
+	rows = append(rows, placeholderDividerRow)
+	for _, peopleRow := range peopleRows {
+		rows = append(rows, []string{
+			peopleRow.Email,
+			humanize.RoughDuration(peopleRow.TimeSinceLastFetch) + " ago",
+			printAdminIfTrue(peopleRow.IsAdmin),
+		})
+		rows = append(rows, placeholderDividerRow)
+	}
+	return rows
+}
+
+var peopleHeader = row{
+	colour.TableHeader("Team Member"),
+	colour.TableHeader("Last Fetched"),
+	colour.TableHeader(""),
+}
+
+func printAdminIfTrue(status bool) string {
+	if status {
+		return "Admin"
+	}
+	return ""
+}

--- a/table/peopletable.go
+++ b/table/peopletable.go
@@ -18,17 +18,13 @@
 package table
 
 import (
-	"time"
-
-	"github.com/fluidkeys/fluidkeys/humanize"
-
 	"github.com/fluidkeys/fluidkeys/colour"
 )
 
 // A PersonRow is used to format a row in the table
 type PersonRow struct {
 	Email              string
-	TimeSinceLastFetch time.Duration
+	TimeSinceLastFetch string
 	IsAdmin            bool
 }
 
@@ -50,7 +46,7 @@ func makePeopleTableRows(peopleRows []PersonRow) (rows []row) {
 	for _, peopleRow := range peopleRows {
 		rows = append(rows, []string{
 			peopleRow.Email,
-			humanize.RoughDuration(peopleRow.TimeSinceLastFetch) + " ago",
+			peopleRow.TimeSinceLastFetch,
 			printAdminIfTrue(peopleRow.IsAdmin),
 		})
 		rows = append(rows, placeholderDividerRow)

--- a/table/table.go
+++ b/table/table.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package table
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fluidkeys/fluidkeys/colour"
+)
+
+// formatTableStringsFromRows takes a slice of rows and coverts it into a slice of
+// strings, padding out the space between the values appropriately.
+// e.g. ["Jane", "4", "Sheffield"], -> "Jane     4   Sheffield",
+//      ["Gillian", "23", "Hull"]      "Gillian  23  Hull     "
+func formatTableStringsFromRows(rows []row) []string {
+	var rowStrings []string
+	maxColumnWidths := getColumnWidths(rows)
+
+	for _, row := range rows {
+		var rowString string
+		for columnIndex, value := range row {
+			if value == divider {
+				rowString += makeDividerString(maxColumnWidths[columnIndex])
+			} else {
+				rowString += makeCellString(value, maxColumnWidths[columnIndex])
+			}
+		}
+		rowString = strings.TrimSuffix(rowString, gutter)
+		rowStrings = append(rowStrings, rowString)
+	}
+
+	return rowStrings
+}
+
+// makeDividerString substitutes in our placeholder '---' with horizontal
+// strings equal to the specified length. For example: 8 -> '────────'
+func makeDividerString(length int) string {
+	return fmt.Sprintf("%s%s", strings.Repeat("─", length), gutter)
+}
+
+func makeCellString(value string, cellLength int) string {
+	return fmt.Sprintf(
+		"%s%s%s",
+		value,
+		// This is more complicated since we have colours on strings
+		strings.Repeat(" ", cellLength-len(colour.StripAllColourCodes(value))),
+		gutter,
+	)
+}
+
+type row = []string
+
+const gutter = "  "
+const divider = "---"

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package table
+
+import (
+	"testing"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+	"github.com/fluidkeys/fluidkeys/colour"
+)
+
+func TestFormatTableStringsFromRows(t *testing.T) {
+	t.Run("with unformatted strings", func(t *testing.T) {
+		rows := []row{
+			row{"Name", "Age", "Location"},
+			row{divider, divider, divider},
+			row{"Gillian", "45", ""},
+			row{divider, divider, divider},
+			row{"Jill", "76", "Sheffield"},
+			row{divider, divider, divider},
+			row{"", "23", ""},
+			row{"", "12", ""},
+		}
+
+		got := formatTableStringsFromRows(rows)
+		want := []string{
+			"Name     Age  Location ",
+			"───────  ───  ─────────",
+			"Gillian  45            ",
+			"───────  ───  ─────────",
+			"Jill     76   Sheffield",
+			"───────  ───  ─────────",
+			"         23            ",
+			"         12            ",
+		}
+
+		assert.AssertEqualSliceOfStrings(t, want, got)
+	})
+
+	t.Run("with coloured strings", func(t *testing.T) {
+		rows := []row{
+			row{colour.TableHeader("Name"), colour.TableHeader("Age")},
+			row{divider, divider},
+			row{"Gillian", "45"},
+		}
+
+		got := formatTableStringsFromRows(rows)
+		want := []string{
+			colour.TableHeader("Name") + "     " + colour.TableHeader("Age"),
+			"───────  ───",
+			"Gillian  45 ",
+		}
+
+		assert.AssertEqualSliceOfStrings(t, want, got)
+	})
+}


### PR DESCRIPTION
This PR handles all of a user's memberships, or rather all keys they are members of a team with.

If prints something that looks like this:
![Screenshot 2019-03-21 at 19 04 28](https://user-images.githubusercontent.com/55195/54778292-31c7b180-4c0c-11e9-93a8-13da0fdd08e0.png)