### PR TITLE
fix bug where emails without <> didn't match

### DIFF
--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -162,9 +162,9 @@ func fetchAndSignTeamKeys(t team.Team, me team.Person, unlockedKey *pgpkey.PgpKe
 				return fmt.Errorf("Got error from Fluidkeys server")
 			}
 
-			if err != key.CertifyEmail(person.Email, unlockedKey, time.Now()) {
+			if err := key.CertifyEmail(person.Email, unlockedKey, time.Now()); err != nil {
 				log.Print(err)
-				return fmt.Errorf("Failed to sign key")
+				return fmt.Errorf("Failed to sign key: %v", err)
 			}
 
 			armoredKey, err := key.Armor()

--- a/pgpkey/certify.go
+++ b/pgpkey/certify.go
@@ -68,8 +68,8 @@ func (p *PgpKey) CertifyEmail(email string, certifier *PgpKey, now time.Time) er
 }
 
 func identitiesMatchingEmail(key *PgpKey, email string) (uids []string) {
-	for _, identity := range key.Identities {
-		if matches(identity.UserId.Email, email) {
+	for raw, identity := range key.Identities {
+		if matches(raw, email) {
 			uids = append(uids, identity.Name)
 		}
 	}
@@ -80,6 +80,6 @@ func identitiesMatchingEmail(key *PgpKey, email string) (uids []string) {
 // is on an existing key. We allow JOHNDOE@example.com to match equal to johndoe@example.com where
 // in other contexts we probably wouldn't (e.g. doing a global key discovery, where those two
 // mail names could actually be different :\
-func matches(email1 string, email2 string) bool {
-	return strings.ToLower(email1) == strings.ToLower(email2)
+func matches(userID string, email2 string) bool {
+	return strings.Contains(strings.ToLower(userID), strings.ToLower(email2))
 }


### PR DESCRIPTION
We were also swallowing the value of the error