### PR TITLE
team apply: don't make misleading claim

### DIFF
--- a/fk/teamapply.go
+++ b/fk/teamapply.go
@@ -143,7 +143,8 @@ func ensureNoExistingRequests(
 		lines :=
 			[]string{
 				formatYouRequestedToJoin(*existingRequest),
-				"The admin hasn't authorized this yet.",
+				"Check if the team admin has authorized your request by running " +
+					colour.Cmd("fk team fetch"),
 				"",
 				"Here are the verification details for your team admin:",
 				"",


### PR DESCRIPTION
requires #463

if someone tries to join a team that they've already got a request to join,
it gave the warning including:

> The admin hasn't authorized this yet.

But that's misleading, since they might have authorized it, and we haven't
run `fk team fetch`

Replace those words with a hint to try `fk team fetch`