### PR TITLE
extend keys annually & extend (don't rotate) subkeys

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -169,17 +169,6 @@ func NextRotation(expiry time.Time) time.Time {
 	return expiry.Add(-sixtyDays)
 }
 
-// IsExpiryTooLong returns true if the expiry is too far in the future.
-//
-// It's important not to raise this warning for expiries that we've set
-// ourselves.
-// We use `NextExpiryTime` such that when we set an expiry date it's *exactly*
-// on the cusp of being too long, and can only get shorter after that point.
-func IsExpiryTooLong(expiry time.Time, now time.Time) bool {
-	latestAcceptableExpiry := NextExpiryTime(now)
-	return expiry.After(latestAcceptableExpiry)
-}
-
 // IsOverdueForRotation returns true if `now` is more than 10 days after
 // nextRotation
 func IsOverdueForRotation(nextRotation time.Time, now time.Time) bool {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -163,11 +163,10 @@ func NextExpiryTime(now time.Time) time.Time {
 	return followingQuarter(oneYearFromNow)
 }
 
-// NextRotation returns 30 days before the earliest expiry time on
-// the key.
+// NextRotation returns 60 days before the earliest expiry time on the key.
 // If the key doesn't expire, it returns nil.
 func NextRotation(expiry time.Time) time.Time {
-	return expiry.Add(-thirtyDays)
+	return expiry.Add(-sixtyDays)
 }
 
 // IsExpiryTooLong returns true if the expiry is too far in the future.
@@ -228,5 +227,6 @@ const (
 	tenDays       time.Duration = time.Duration(time.Hour * 24 * 10)
 	thirtyDays    time.Duration = time.Duration(time.Hour * 24 * 30)
 	fortyFiveDays time.Duration = time.Duration(time.Hour * 24 * 45)
+	sixtyDays     time.Duration = time.Duration(time.Hour * 24 * 60)
 	oneYear       time.Duration = time.Duration(time.Hour * 24 * 365)
 )

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -64,7 +64,7 @@ func TestFollowingQuarter(t *testing.T) {
 			gotOutput := followingQuarter(test.today)
 
 			if test.expectedOutput != gotOutput {
-				t.Fatalf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
+				t.Errorf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
 			}
 		})
 	}
@@ -115,7 +115,7 @@ func TestNextExpiryTime(t *testing.T) {
 			gotOutput := NextExpiryTime(test.today)
 
 			if test.expectedOutput != gotOutput {
-				t.Fatalf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
+				t.Errorf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
 			}
 		})
 	}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -9,12 +9,14 @@ import (
 var (
 	feb1st           = time.Date(2018, 2, 1, 0, 0, 0, 0, time.UTC)
 	march1st         = time.Date(2018, 3, 1, 0, 0, 0, 0, time.UTC)
+	may1st           = time.Date(2018, 5, 1, 0, 0, 0, 0, time.UTC)
+	may1stLeapYear   = time.Date(2020, 5, 1, 0, 0, 0, 0, time.UTC)
 	march1stLeapYear = time.Date(2020, 3, 1, 0, 0, 0, 0, time.UTC)
 
 	anotherTimezone = time.FixedZone("UTC+8", 8*60*60)
 )
 
-func TestFirstOfNextMonth(t *testing.T) {
+func TestFollowingQuarter(t *testing.T) {
 	var tests = []struct {
 		today          time.Time
 		expectedOutput time.Time
@@ -33,33 +35,33 @@ func TestFirstOfNextMonth(t *testing.T) {
 		},
 		{
 			time.Date(2018, 2, 1, 18, 0, 0, 0, time.UTC), // start of Feb
-			march1st,
+			may1st,
 		},
 		{
 			time.Date(2018, 2, 15, 18, 0, 0, 0, time.UTC), // middle of Feb
-			march1st,
+			may1st,
 		},
 		{
 			time.Date(2018, 2, 28, 23, 59, 59, 0, time.UTC), // end of Feb
-			march1st,
+			may1st,
 		},
 		{
 			time.Date(2020, 2, 29, 23, 59, 59, 0, time.UTC), // end of Feb, leap year
-			march1stLeapYear,
+			may1stLeapYear,
 		},
 		{
 			time.Date(2020, 2, 29, 23, 59, 59, 0, time.UTC), // end of Feb, leap year
-			march1stLeapYear,
+			may1stLeapYear,
 		},
 		{
 			time.Date(2018, 2, 15, 12, 0, 0, 0, anotherTimezone), // non-UTC
-			time.Date(2018, 3, 1, 0, 0, 0, 0, time.UTC),          // should convert timezone
+			time.Date(2018, 5, 1, 0, 0, 0, 0, time.UTC),          // should convert timezone
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("today = %v", test.today), func(t *testing.T) {
-			gotOutput := firstOfNextMonth(test.today)
+			gotOutput := followingQuarter(test.today)
 
 			if test.expectedOutput != gotOutput {
 				t.Fatalf("expected '%s', got '%s'", test.expectedOutput, gotOutput)
@@ -76,35 +78,35 @@ func TestNextExpiryTime(t *testing.T) {
 	}{
 		{
 			time.Date(2018, 1, 1, 18, 0, 0, 0, time.UTC), // start of Jan
-			feb1st.Add(thirtyDays),
+			time.Date(2019, 2, 1, 0, 0, 0, 0, time.UTC),  // 1st Feb (next year)
 		},
 		{
 			time.Date(2018, 1, 15, 18, 0, 0, 0, time.UTC), // middle of Jan
-			feb1st.Add(thirtyDays),
+			time.Date(2019, 2, 1, 0, 0, 0, 0, time.UTC),   // 1st Feb (next year)
 		},
 		{
 			time.Date(2018, 1, 31, 23, 59, 59, 0, time.UTC), // end of Jan
-			feb1st.Add(thirtyDays),
+			time.Date(2019, 2, 1, 0, 0, 0, 0, time.UTC),     // 1st Feb (next year)
 		},
 		{
 			time.Date(2018, 2, 1, 18, 0, 0, 0, time.UTC), // start of Feb
-			march1st.Add(thirtyDays),
+			time.Date(2019, 5, 1, 0, 0, 0, 0, time.UTC),  // 1st May (next year)
 		},
 		{
 			time.Date(2018, 2, 15, 18, 0, 0, 0, time.UTC), // middle of Feb
-			march1st.Add(thirtyDays),
+			time.Date(2019, 5, 1, 0, 0, 0, 0, time.UTC),   // 1st May (next year)
 		},
 		{
 			time.Date(2018, 2, 28, 23, 59, 59, 0, time.UTC), // end of Feb
-			march1st.Add(thirtyDays),
+			time.Date(2019, 5, 1, 0, 0, 0, 0, time.UTC),     // 1st May (next year)
 		},
 		{
 			time.Date(2020, 2, 29, 23, 59, 59, 0, time.UTC), // end of Feb, leap year
-			march1stLeapYear.Add(thirtyDays),
+			time.Date(2021, 5, 1, 0, 0, 0, 0, time.UTC),     // 1st may (year +1)
 		},
 		{
 			time.Date(2018, 2, 15, 18, 0, 0, 0, anotherTimezone), // non-UTC
-			time.Date(2018, 3, 31, 0, 0, 0, 0, time.UTC),         // should convert to UTC
+			time.Date(2019, 5, 1, 0, 0, 0, 0, time.UTC),          // should convert to UTC
 		},
 	}
 

--- a/status/actions.go
+++ b/status/actions.go
@@ -71,8 +71,10 @@ func makeActionsFromSingleWarning(warning KeyWarning, now time.Time) []KeyAction
 
 	case SubkeyDueForRotation, SubkeyOverdueForRotation, SubkeyNoExpiry:
 		return []KeyAction{
-			CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
-			ExpireSubkey{SubkeyId: warning.SubkeyId},
+			ModifySubkeyExpiry{
+				subkeyId:   warning.SubkeyId,
+				validUntil: nextExpiry,
+			},
 		}
 
 	case NoValidEncryptionSubkey:

--- a/status/actions.go
+++ b/status/actions.go
@@ -63,13 +63,13 @@ func makeActionsFromSingleWarning(warning KeyWarning, now time.Time) []KeyAction
 	nextExpiry := policy.NextExpiryTime(now)
 
 	switch warning.Type {
-	case PrimaryKeyDueForRotation, PrimaryKeyOverdueForRotation, PrimaryKeyNoExpiry, PrimaryKeyLongExpiry, PrimaryKeyExpired:
+	case PrimaryKeyDueForRotation, PrimaryKeyOverdueForRotation, PrimaryKeyNoExpiry, PrimaryKeyExpired:
 
 		return []KeyAction{
 			ModifyPrimaryKeyExpiry{ValidUntil: nextExpiry, PreviouslyValidUntil: warning.CurrentValidUntil},
 		}
 
-	case SubkeyDueForRotation, SubkeyOverdueForRotation, SubkeyLongExpiry, SubkeyNoExpiry:
+	case SubkeyDueForRotation, SubkeyOverdueForRotation, SubkeyNoExpiry:
 		return []KeyAction{
 			CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
 			ExpireSubkey{SubkeyId: warning.SubkeyId},

--- a/status/actions_test.go
+++ b/status/actions_test.go
@@ -53,13 +53,6 @@ func TestMakeActionsFromSingleWarning(t *testing.T) {
 			},
 		},
 		{
-			PrimaryKeyLongExpiry,
-			0,
-			[]KeyAction{
-				ModifyPrimaryKeyExpiry{ValidUntil: nextExpiry},
-			},
-		},
-		{
 			NoValidEncryptionSubkey,
 			0,
 			[]KeyAction{
@@ -84,14 +77,6 @@ func TestMakeActionsFromSingleWarning(t *testing.T) {
 		},
 		{
 			SubkeyNoExpiry,
-			9999,
-			[]KeyAction{
-				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
-				ExpireSubkey{SubkeyId: 9999},
-			},
-		},
-		{
-			SubkeyLongExpiry,
 			9999,
 			[]KeyAction{
 				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
@@ -268,14 +253,12 @@ func TestMakeActionsFromWarnings(t *testing.T) {
 		KeyWarning{Type: PrimaryKeyOverdueForRotation},
 		KeyWarning{Type: PrimaryKeyExpired},
 		KeyWarning{Type: PrimaryKeyNoExpiry},
-		KeyWarning{Type: PrimaryKeyLongExpiry},
 		KeyWarning{Type: NoValidEncryptionSubkey},
 		KeyWarning{Type: SubkeyDueForRotation, SubkeyId: 0x1111},
 		KeyWarning{Type: SubkeyDueForRotation, SubkeyId: 0x2222},
 		KeyWarning{Type: SubkeyOverdueForRotation, SubkeyId: 0x1111},
 		KeyWarning{Type: SubkeyOverdueForRotation, SubkeyId: 0x2222},
 		KeyWarning{Type: SubkeyNoExpiry, SubkeyId: 0x1111},
-		KeyWarning{Type: SubkeyLongExpiry, SubkeyId: 0x2222},
 		KeyWarning{Type: MissingPreferredSymmetricAlgorithms},
 		KeyWarning{Type: WeakPreferredSymmetricAlgorithms},
 		KeyWarning{Type: UnsupportedPreferredSymmetricAlgorithm},

--- a/status/actions_test.go
+++ b/status/actions_test.go
@@ -63,24 +63,30 @@ func TestMakeActionsFromSingleWarning(t *testing.T) {
 			SubkeyDueForRotation,
 			9999,
 			[]KeyAction{
-				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
-				ExpireSubkey{SubkeyId: 9999},
+				ModifySubkeyExpiry{
+					validUntil: nextExpiry,
+					subkeyId:   9999,
+				},
 			},
 		},
 		{
 			SubkeyOverdueForRotation,
 			9999,
 			[]KeyAction{
-				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
-				ExpireSubkey{SubkeyId: 9999},
+				ModifySubkeyExpiry{
+					validUntil: nextExpiry,
+					subkeyId:   9999,
+				},
 			},
 		},
 		{
 			SubkeyNoExpiry,
 			9999,
 			[]KeyAction{
-				CreateNewEncryptionSubkey{ValidUntil: nextExpiry},
-				ExpireSubkey{SubkeyId: 9999},
+				ModifySubkeyExpiry{
+					validUntil: nextExpiry,
+					subkeyId:   9999,
+				},
 			},
 		},
 		{
@@ -214,7 +220,7 @@ func TestDeduplicateAndOrder(t *testing.T) {
 
 	t.Run("order should be primary key actions > preferences > subkey actions", func(t *testing.T) {
 		inputActions := []KeyAction{
-			ExpireSubkey{SubkeyId: 9999},
+			ModifySubkeyExpiry{subkeyId: 9999},
 			SetPreferredCompressionAlgorithms{},
 			ModifyPrimaryKeyExpiry{},
 		}
@@ -222,7 +228,7 @@ func TestDeduplicateAndOrder(t *testing.T) {
 		expectedActions := []KeyAction{
 			ModifyPrimaryKeyExpiry{},
 			SetPreferredCompressionAlgorithms{},
-			ExpireSubkey{SubkeyId: 9999},
+			ModifySubkeyExpiry{subkeyId: 9999},
 		}
 		gotActions := deduplicateAndOrder(inputActions)
 		assertActionsEqual(t, expectedActions, gotActions)
@@ -230,13 +236,13 @@ func TestDeduplicateAndOrder(t *testing.T) {
 
 	t.Run("doesn't de-duplicate actions for different subkeys", func(t *testing.T) {
 		inputActions := []KeyAction{
-			ExpireSubkey{SubkeyId: 1234},
-			ExpireSubkey{SubkeyId: 4567},
+			ModifySubkeyExpiry{subkeyId: 1234},
+			ModifySubkeyExpiry{subkeyId: 4567},
 		}
 
 		expectedActions := []KeyAction{
-			ExpireSubkey{SubkeyId: 1234},
-			ExpireSubkey{SubkeyId: 4567},
+			ModifySubkeyExpiry{subkeyId: 1234},
+			ModifySubkeyExpiry{subkeyId: 4567},
 		}
 
 		gotActions := deduplicateAndOrder(inputActions)
@@ -253,7 +259,6 @@ func TestMakeActionsFromWarnings(t *testing.T) {
 		KeyWarning{Type: PrimaryKeyOverdueForRotation},
 		KeyWarning{Type: PrimaryKeyExpired},
 		KeyWarning{Type: PrimaryKeyNoExpiry},
-		KeyWarning{Type: NoValidEncryptionSubkey},
 		KeyWarning{Type: SubkeyDueForRotation, SubkeyId: 0x1111},
 		KeyWarning{Type: SubkeyDueForRotation, SubkeyId: 0x2222},
 		KeyWarning{Type: SubkeyOverdueForRotation, SubkeyId: 0x1111},
@@ -278,9 +283,14 @@ func TestMakeActionsFromWarnings(t *testing.T) {
 		SetPreferredSymmetricAlgorithms{NewPreferences: policy.AdvertiseCipherPreferences},
 		SetPreferredHashAlgorithms{NewPreferences: policy.AdvertiseHashPreferences},
 		SetPreferredCompressionAlgorithms{NewPreferences: policy.AdvertiseCompressionPreferences},
-		CreateNewEncryptionSubkey{ValidUntil: time.Date(2019, 8, 1, 0, 0, 0, 0, time.UTC)},
-		ExpireSubkey{SubkeyId: 0x1111},
-		ExpireSubkey{SubkeyId: 0x2222},
+		ModifySubkeyExpiry{
+			validUntil: time.Date(2019, 8, 1, 0, 0, 0, 0, time.UTC),
+			subkeyId:   0x1111,
+		},
+		ModifySubkeyExpiry{
+			validUntil: time.Date(2019, 8, 1, 0, 0, 0, 0, time.UTC),
+			subkeyId:   0x2222,
+		},
 		RefreshUserIdSelfSignatures{},
 		RefreshSubkeyBindingSignature{SubkeyId: 0x1111},
 	}

--- a/status/actions_test.go
+++ b/status/actions_test.go
@@ -291,11 +291,11 @@ func TestMakeActionsFromWarnings(t *testing.T) {
 
 	now := time.Date(2018, 6, 15, 0, 0, 0, 0, time.UTC)
 	expectedActions := []KeyAction{
-		ModifyPrimaryKeyExpiry{ValidUntil: time.Date(2018, 7, 31, 0, 0, 0, 0, time.UTC)},
+		ModifyPrimaryKeyExpiry{ValidUntil: time.Date(2019, 8, 1, 0, 0, 0, 0, time.UTC)},
 		SetPreferredSymmetricAlgorithms{NewPreferences: policy.AdvertiseCipherPreferences},
 		SetPreferredHashAlgorithms{NewPreferences: policy.AdvertiseHashPreferences},
 		SetPreferredCompressionAlgorithms{NewPreferences: policy.AdvertiseCompressionPreferences},
-		CreateNewEncryptionSubkey{ValidUntil: time.Date(2018, 7, 31, 0, 0, 0, 0, time.UTC)},
+		CreateNewEncryptionSubkey{ValidUntil: time.Date(2019, 8, 1, 0, 0, 0, 0, time.UTC)},
 		ExpireSubkey{SubkeyId: 0x1111},
 		ExpireSubkey{SubkeyId: 0x2222},
 		RefreshUserIdSelfSignatures{},

--- a/status/keyactions.go
+++ b/status/keyactions.go
@@ -72,26 +72,6 @@ func (a CreateNewEncryptionSubkey) SortOrder() int {
 	return sortOrderCreateSubkey
 }
 
-// ExpireSubkey updates and re-signs the self signature on the given subkey to
-// now, in order that the subkey becomes effectively unusable (although it
-// could be updated again to bring the subkey back to life, unlike it it were
-// revoked)
-type ExpireSubkey struct {
-	KeyAction
-
-	SubkeyId uint64
-}
-
-func (a ExpireSubkey) Enact(key *pgpkey.PgpKey, now time.Time, password *string) error {
-	return key.ExpireSubkey(a.SubkeyId, now)
-}
-func (a ExpireSubkey) String() string {
-	return fmt.Sprintf("Expire the encryption subkey now (0x%X)", a.SubkeyId)
-}
-func (a ExpireSubkey) SortOrder() int {
-	return sortOrderModifySubkey
-}
-
 // ModifySubkeyExpiry iterates over all user IDs. For each UID, it updates
 // the expiry date on the *self signature*.
 // It re-signs the self signature.

--- a/status/keyactions.go
+++ b/status/keyactions.go
@@ -92,6 +92,27 @@ func (a ExpireSubkey) SortOrder() int {
 	return sortOrderModifySubkey
 }
 
+// ModifySubkeyExpiry iterates over all user IDs. For each UID, it updates
+// the expiry date on the *self signature*.
+// It re-signs the self signature.
+type ModifySubkeyExpiry struct {
+	KeyAction
+
+	validUntil time.Time
+	subkeyId   uint64
+}
+
+func (a ModifySubkeyExpiry) Enact(key *pgpkey.PgpKey, now time.Time, password *string) error {
+	return key.UpdateSubkeyValidUntil(a.subkeyId, a.validUntil, now)
+}
+
+func (a ModifySubkeyExpiry) String() string {
+	return fmt.Sprintf("Extend encryption subkey expiry to %s", a.validUntil.Format("2 Jan 06"))
+}
+func (a ModifySubkeyExpiry) SortOrder() int {
+	return sortOrderModifySubkey
+}
+
 // SetPreferredSymmetricAlgorithms iterates over all user IDs, setting the preferred
 // symmetric algorithm preferences from NewPreferences
 // It re-signs the self signature on each user ID.

--- a/status/keyactions.go
+++ b/status/keyactions.go
@@ -43,9 +43,9 @@ func (a ModifyPrimaryKeyExpiry) Enact(key *pgpkey.PgpKey, now time.Time, passwor
 
 func (a ModifyPrimaryKeyExpiry) String() string {
 	if a.PreviouslyValidUntil == nil || a.PreviouslyValidUntil.After(a.ValidUntil) {
-		return fmt.Sprintf("Shorten the primary key expiry to %s", a.ValidUntil.Format("2 Jan 06"))
+		return fmt.Sprintf("Shorten the primary key expiry to %s", a.ValidUntil.Format("2 Jan 2006"))
 	} else {
-		return fmt.Sprintf("Extend the primary key expiry to %s", a.ValidUntil.Format("2 Jan 06"))
+		return fmt.Sprintf("Extend the primary key expiry to %s", a.ValidUntil.Format("2 Jan 2006"))
 	}
 }
 func (a ModifyPrimaryKeyExpiry) SortOrder() int {
@@ -65,7 +65,7 @@ func (a CreateNewEncryptionSubkey) Enact(key *pgpkey.PgpKey, now time.Time, pass
 }
 
 func (a CreateNewEncryptionSubkey) String() string {
-	return fmt.Sprintf("Create a new encryption subkey valid until %s", a.ValidUntil.Format("2 Jan 06"))
+	return fmt.Sprintf("Create a new encryption subkey valid until %s", a.ValidUntil.Format("2 Jan 2006"))
 }
 
 func (a CreateNewEncryptionSubkey) SortOrder() int {

--- a/status/keywarning.go
+++ b/status/keywarning.go
@@ -34,13 +34,13 @@ const (
 	PrimaryKeyOverdueForRotation = 2
 	PrimaryKeyExpired            = 3
 	PrimaryKeyNoExpiry           = 4
-	PrimaryKeyLongExpiry         = 5
+	// deleted: PrimaryKeyLongExpiry         = 5
 
 	NoValidEncryptionSubkey  = 6
 	SubkeyDueForRotation     = 7
 	SubkeyOverdueForRotation = 8
 	SubkeyNoExpiry           = 9
-	SubkeyLongExpiry         = 10
+	// deleted: SubkeyLongExpiry         = 10
 
 	MissingPreferredSymmetricAlgorithms    = 11
 	WeakPreferredSymmetricAlgorithms       = 12
@@ -89,9 +89,6 @@ func (w KeyWarning) String() string {
 	case PrimaryKeyNoExpiry:
 		return "Primary key never expires"
 
-	case PrimaryKeyLongExpiry:
-		return "Primary key expires too far in the future"
-
 	case NoValidEncryptionSubkey:
 		return colour.Danger("Missing encryption subkey")
 
@@ -103,9 +100,6 @@ func (w KeyWarning) String() string {
 
 	case SubkeyNoExpiry:
 		return "Encryption subkey never expires"
-
-	case SubkeyLongExpiry:
-		return "Encryption subkey expires too far in the future"
 
 	case MissingPreferredSymmetricAlgorithms:
 		return "Missing cipher preferences"

--- a/status/keywarning.go
+++ b/status/keywarning.go
@@ -93,10 +93,10 @@ func (w KeyWarning) String() string {
 		return colour.Danger("Missing encryption subkey")
 
 	case SubkeyDueForRotation:
-		return "Encryption subkey needs rotating"
+		return "Encryption subkey needs extending"
 
 	case SubkeyOverdueForRotation:
-		return colour.Danger("Encryption subkey needs rotating now (" + countdownUntilExpiry(w.DaysUntilExpiry) + ")")
+		return colour.Danger("Encryption subkey needs extending now (" + countdownUntilExpiry(w.DaysUntilExpiry) + ")")
 
 	case SubkeyNoExpiry:
 		return "Encryption subkey never expires"

--- a/status/keywarning_test.go
+++ b/status/keywarning_test.go
@@ -28,7 +28,7 @@ func TestString(t *testing.T) {
 		},
 		{
 			KeyWarning{Type: SubkeyOverdueForRotation, DaysUntilExpiry: 5},
-			colour.Danger("Encryption subkey needs rotating now (expires in 5 days)"),
+			colour.Danger("Encryption subkey needs extending now (expires in 5 days)"),
 		},
 		{
 			KeyWarning{Type: PrimaryKeyExpired, DaysSinceExpiry: 0},

--- a/status/status.go
+++ b/status/status.go
@@ -99,14 +99,6 @@ func getEncryptionSubkeyWarnings(key pgpkey.PgpKey, now time.Time) []KeyWarning 
 			warnings = append(warnings, warning)
 		}
 
-		if policy.IsExpiryTooLong(*expiry, now) {
-			warning := KeyWarning{
-				Type:              SubkeyLongExpiry,
-				SubkeyId:          subkeyId,
-				CurrentValidUntil: expiry,
-			}
-			warnings = append(warnings, warning)
-		}
 	} else { // no expiry
 		warning := KeyWarning{
 			Type:     SubkeyNoExpiry,
@@ -151,13 +143,6 @@ func getPrimaryKeyWarnings(key pgpkey.PgpKey, now time.Time) []KeyWarning {
 			warnings = append(warnings, warning)
 		}
 
-		if policy.IsExpiryTooLong(*expiry, now) {
-			warning := KeyWarning{
-				Type:              PrimaryKeyLongExpiry,
-				CurrentValidUntil: expiry,
-			}
-			warnings = append(warnings, warning)
-		}
 	} else { // no expiry
 		warning := KeyWarning{Type: PrimaryKeyNoExpiry}
 		warnings = append(warnings, warning)

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -138,17 +138,6 @@ func TestGetEncryptionSubkeyWarnings(t *testing.T) {
 
 			assertEqualSliceOfKeyWarningTypes(t, expected, got)
 		})
-
-		t.Run("test we get primary key long expiry warning", func(t *testing.T) {
-			expected := []KeyWarning{
-				KeyWarning{Type: PrimaryKeyLongExpiry},
-			}
-
-			now := time.Date(2018, 9, 24, 18, 0, 0, 0, time.UTC)
-			got := getPrimaryKeyWarnings(*pgpKey, now)
-
-			assertEqualSliceOfKeyWarningTypes(t, expected, got)
-		})
 	})
 }
 


### PR DESCRIPTION
after extensive testing, we've realised the world isn't ready for fast-expiring PGP keys!

this PR introduces the following changes:

1. keys last ~1 year
   previously, keys expired 30 after 1st of next month
   now, keys expire in 1 year *rounded* to the next quarter (1st feb, may, august or november)
   This means there will only be 4 dates in the year when expiries occur, allowing teams to
   help each other out 

2. extend (don't rotate) subkeys
   creating new subkeys can cause trouble with multiple devices, and using a single password
   for primary & subkeys is a false sense of security.
   instead, just extend subkeys the same as the primary key

3. start trying to extend 60 days before the expiry date (previously it was 30)
   so if your expiry date is 1st May, on 2nd March (60 days before), fk will start trying to
   extend your key. This gives us *plenty* of time to notify people if that isn't working
   (e.g. at -45 days, which is still well before 30 day warnings from e.g. Enigmail)


* implements this card: https://trello.com/c/yA2hEInD
* fixes this bug (enigmail warning): https://trello.com/c/hRS7LE7D