### PR TITLE
GetLast, RecordLast: supporting anything with .String (a 'Stringer')

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"time"
 
@@ -166,11 +167,22 @@ func makeMapKey(verb string, item interface{}) (string, error) {
 	case team.Team:
 		itemKey = teamItem + ":" + i.UUID.String()
 
+	case fmt.Stringer: // does it have .String() ?
+		itemKey = getType(i) + ":" + i.String()
+
 	default:
 		return "", fmt.Errorf("don't know how to handle %#v", item)
 	}
 
 	return verb + ":" + itemKey, nil
+}
+
+func getType(myvar interface{}) string {
+	t := reflect.TypeOf(myvar)
+	if t.Kind() == reflect.Ptr {
+		return t.Elem().Name()
+	}
+	return t.Name()
 }
 
 // IsOlderThan takes a verb and item and returns true if it was last recorded more than `age` ago.

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -348,6 +348,10 @@ func TestGetExistingRequestToJoinTeam(t *testing.T) {
 	})
 }
 
+type arbitraryStruct struct{}
+
+func (a arbitraryStruct) String() string { return "result of arbitraryStruct.String()" }
+
 func TestEventTimes(t *testing.T) {
 	now := time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
 	later := now.Add(time.Duration(6) * time.Hour)
@@ -366,6 +370,21 @@ func TestEventTimes(t *testing.T) {
 
 			assert.Equal(t, "example-verb:key:OPENPGP4FPR:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", key)
 		})
+
+		t.Run("with arbitraryStruct (that has String())", func(t *testing.T) {
+			key, err := makeMapKey("example-verb", arbitraryStruct{})
+			assert.NoError(t, err)
+
+			assert.Equal(t, "example-verb:arbitraryStruct:result of arbitraryStruct.String()", key)
+		})
+
+		t.Run("with *arbitraryStruct (that has String())", func(t *testing.T) {
+			key, err := makeMapKey("example-verb", &arbitraryStruct{})
+			assert.NoError(t, err)
+
+			assert.Equal(t, "example-verb:arbitraryStruct:result of arbitraryStruct.String()", key)
+		})
+
 	})
 
 	t.Run("record last", func(t *testing.T) {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -352,6 +352,22 @@ func TestEventTimes(t *testing.T) {
 	now := time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
 	later := now.Add(time.Duration(6) * time.Hour)
 
+	t.Run("makeMapKey", func(t *testing.T) {
+		t.Run("with Fingerprint", func(t *testing.T) {
+			key, err := makeMapKey("example-verb", exampleFingerprintA)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "example-verb:key:OPENPGP4FPR:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", key)
+		})
+
+		t.Run("with *Fingerprint", func(t *testing.T) {
+			key, err := makeMapKey("example-verb", &exampleFingerprintA)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "example-verb:key:OPENPGP4FPR:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", key)
+		})
+	})
+
 	t.Run("record last", func(t *testing.T) {
 		database := New(testhelpers.Maketemp(t))
 		t.Run("doesn't error given a verb and handled item", func(t *testing.T) {


### PR DESCRIPTION
any struct that implements the interface `fmt.Stringer` by defining
.String()

I need this to be able to record that key A was certified by key B. I need
both bit of information, not just one, so I'll implement a struct
`recordOfCertification` whose `String()` method returns e.g.
`aaa-certified-by-bbb`