### PR TITLE
team fetch: only certify keys once

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"time"
 
@@ -166,11 +167,22 @@ func makeMapKey(verb string, item interface{}) (string, error) {
 	case team.Team:
 		itemKey = teamItem + ":" + i.UUID.String()
 
+	case fmt.Stringer: // does it have .String() ?
+		itemKey = getType(i) + ":" + i.String()
+
 	default:
 		return "", fmt.Errorf("don't know how to handle %#v", item)
 	}
 
 	return verb + ":" + itemKey, nil
+}
+
+func getType(myvar interface{}) string {
+	t := reflect.TypeOf(myvar)
+	if t.Kind() == reflect.Ptr {
+		return t.Elem().Name()
+	}
+	return t.Name()
 }
 
 // IsOlderThan takes a verb and item and returns true if it was last recorded more than `age` ago.

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -348,6 +348,10 @@ func TestGetExistingRequestToJoinTeam(t *testing.T) {
 	})
 }
 
+type arbitraryStruct struct{}
+
+func (a arbitraryStruct) String() string { return "result of arbitraryStruct.String()" }
+
 func TestEventTimes(t *testing.T) {
 	now := time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
 	later := now.Add(time.Duration(6) * time.Hour)
@@ -366,6 +370,21 @@ func TestEventTimes(t *testing.T) {
 
 			assert.Equal(t, "example-verb:key:OPENPGP4FPR:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", key)
 		})
+
+		t.Run("with arbitraryStruct (that has String())", func(t *testing.T) {
+			key, err := makeMapKey("example-verb", arbitraryStruct{})
+			assert.NoError(t, err)
+
+			assert.Equal(t, "example-verb:arbitraryStruct:result of arbitraryStruct.String()", key)
+		})
+
+		t.Run("with *arbitraryStruct (that has String())", func(t *testing.T) {
+			key, err := makeMapKey("example-verb", &arbitraryStruct{})
+			assert.NoError(t, err)
+
+			assert.Equal(t, "example-verb:arbitraryStruct:result of arbitraryStruct.String()", key)
+		})
+
 	})
 
 	t.Run("record last", func(t *testing.T) {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -352,6 +352,22 @@ func TestEventTimes(t *testing.T) {
 	now := time.Date(2019, 6, 20, 16, 35, 0, 0, time.UTC)
 	later := now.Add(time.Duration(6) * time.Hour)
 
+	t.Run("makeMapKey", func(t *testing.T) {
+		t.Run("with Fingerprint", func(t *testing.T) {
+			key, err := makeMapKey("example-verb", exampleFingerprintA)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "example-verb:key:OPENPGP4FPR:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", key)
+		})
+
+		t.Run("with *Fingerprint", func(t *testing.T) {
+			key, err := makeMapKey("example-verb", &exampleFingerprintA)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "example-verb:key:OPENPGP4FPR:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", key)
+		})
+	})
+
 	t.Run("record last", func(t *testing.T) {
 		database := New(testhelpers.Maketemp(t))
 		t.Run("doesn't error given a verb and handled item", func(t *testing.T) {

--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -82,7 +82,7 @@ func doUpdateTeam(myTeam *team.Team, me *team.Person, unattended bool) (err erro
 	}
 	myTeam = updatedTeam // move myTeam pointer to updatedTeam
 
-	if err := fetchAndSignTeamKeys(*myTeam, *me, unlockedKey, alwaysDownload); err != nil {
+	if err := fetchAndCertifyTeamKeys(*myTeam, *me, unlockedKey, alwaysDownload); err != nil {
 		out.Print(ui.FormatWarning("Error fetching team keys", nil, err))
 		return err
 	}
@@ -163,10 +163,10 @@ func fetchAndUpdateRoster(t team.Team, unlockedKey *pgpkey.PgpKey, alwaysDownloa
 	return updatedTeam, nil
 }
 
-// fetchAndSignTeamKeys fetches each key listed in the team and locally signs them in GnuPG
+// fetchAndCertifyTeamKeys fetches each key listed in the team and locally signs them in GnuPG
 // if `alwaysDownload` is false, it will only try to fetch keys every 24 hours, otherwise it'll
 // check every time.
-func fetchAndSignTeamKeys(
+func fetchAndCertifyTeamKeys(
 	t team.Team, me team.Person, unlockedKey *pgpkey.PgpKey, alwaysDownload bool) (err error) {
 
 	out.Print("Fetching and signing keys for other members of " + t.Name + ":\n\n")


### PR DESCRIPTION
the end goal here is that *normally*, `fk sync` doesn't require an unlocked
key.

that's good because:

1. we shouldn't unlock a key if it's not strictly necessary
2. we can add error reporting to the unlock key routine, and we'll only
  see errors when they actually matter (e.g. a new team member has
  joined the team, and their key needs certifying)