### PR TITLE
rename api / client / apiclient

### DIFF
--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
 
-package api
+package apiclient
 
 import (
 	"bytes"

--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -63,8 +63,8 @@ var (
 	ErrForbidden = fmt.Errorf("Forbidden")
 )
 
-// NewClient returns a new Fluidkeys Server API client.
-func NewClient(fluidkeysVersion string) *Client {
+// New returns a new Fluidkeys Server API client.
+func New(fluidkeysVersion string) *Client {
 	apiURL, got := os.LookupEnv("FLUIDKEYS_API_URL") // e.g. http://localhost:4747/v1/
 	if !got {
 		apiURL = defaultBaseURL

--- a/apiclient/apiclient_test.go
+++ b/apiclient/apiclient_test.go
@@ -835,7 +835,7 @@ func setup() (client *Client, mux *http.ServeMux, serverURL string, teardown fun
 
 	// client is the Fluidkeys Server client being tested and is
 	// configured to use test server.
-	client = NewClient("vtest")
+	client = New("vtest")
 	url, _ := url.Parse(server.URL + "/")
 	client.BaseURL = url
 

--- a/apiclient/apiclient_test.go
+++ b/apiclient/apiclient_test.go
@@ -1,4 +1,4 @@
-package api
+package apiclient
 
 import (
 	"bytes"

--- a/fk/init.go
+++ b/fk/init.go
@@ -95,7 +95,7 @@ func initOutput() {
 }
 
 func initAPIClient() {
-	client = apiclient.New(Version)
+	api = apiclient.New(Version)
 }
 
 func initUser() {

--- a/fk/init.go
+++ b/fk/init.go
@@ -95,7 +95,7 @@ func initOutput() {
 }
 
 func initAPIClient() {
-	client = apiclient.NewClient(Version)
+	client = apiclient.New(Version)
 }
 
 func initUser() {

--- a/fk/init.go
+++ b/fk/init.go
@@ -24,7 +24,7 @@ import (
 
 	"path/filepath"
 
-	"github.com/fluidkeys/fluidkeys/api"
+	"github.com/fluidkeys/fluidkeys/apiclient"
 	"github.com/fluidkeys/fluidkeys/config"
 	"github.com/fluidkeys/fluidkeys/database"
 	"github.com/fluidkeys/fluidkeys/gpgwrapper"
@@ -95,7 +95,7 @@ func initOutput() {
 }
 
 func initAPIClient() {
-	client = api.NewClient(Version)
+	client = apiclient.NewClient(Version)
 }
 
 func initUser() {

--- a/fk/keycreate.go
+++ b/fk/keycreate.go
@@ -138,7 +138,7 @@ func keyCreate(email string) (exitCode, *pgpkey.PgpKey) {
 		time.Sleep(spinnerTimeDelay)
 		if time.Since(timeLastPolled).Seconds() > 5 {
 			verifiedEmailResult, err = verifyEmailMatchesKeyInAPI(
-				email, generateJob.pgpKey.Fingerprint(), client)
+				email, generateJob.pgpKey.Fingerprint(), api)
 			if err != nil {
 				out.Print("\n\n")
 				printFailed(fmt.Sprintf("Failed to verify email: %s", err))

--- a/fk/keyupload.go
+++ b/fk/keyupload.go
@@ -93,7 +93,7 @@ func publishKeyToAPI(privateKey *pgpkey.PgpKey) error {
 	if err != nil {
 		return fmt.Errorf("Couldn't load armored key: %s", err)
 	}
-	if err = client.UpsertPublicKey(armoredPublicKey, privateKey); err != nil {
+	if err = api.UpsertPublicKey(armoredPublicKey, privateKey); err != nil {
 		return fmt.Errorf("Failed to upload public key: %s", err)
 
 	}

--- a/fk/main.go
+++ b/fk/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/status"
 	"github.com/fluidkeys/fluidkeys/table"
 
-	"github.com/fluidkeys/fluidkeys/api"
+	"github.com/fluidkeys/fluidkeys/apiclient"
 	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 
 	"github.com/docopt/docopt-go"
@@ -53,7 +53,7 @@ var (
 	db                 database.Database
 	Config             config.Config
 	Keyring            keyring.Keyring
-	client             *api.Client
+	client             *apiclient.Client
 	user               *userpackage.User
 )
 

--- a/fk/main.go
+++ b/fk/main.go
@@ -53,7 +53,7 @@ var (
 	db                 database.Database
 	Config             config.Config
 	Keyring            keyring.Keyring
-	client             *apiclient.Client
+	api                *apiclient.Client
 	user               *userpackage.User
 )
 

--- a/fk/secretreceive.go
+++ b/fk/secretreceive.go
@@ -59,7 +59,7 @@ func secretReceive() exitCode {
 	sawError := false
 	numSecretsDeleted := 0
 
-	secretLister := client
+	secretLister := api
 
 	for _, key := range keys {
 		if !Config.ShouldPublishToAPI(key.Fingerprint()) {
@@ -113,7 +113,7 @@ func secretReceive() exitCode {
 				}
 			}
 
-			err := client.DeleteSecret(key.Fingerprint(), secret.UUID.String())
+			err := api.DeleteSecret(key.Fingerprint(), secret.UUID.String())
 			if err != nil {
 				log.Printf("failed to delete secret '%s': %v", secret.UUID, err)
 				printFailed("Error when secret tried to self-destruct:")

--- a/fk/secretsend.go
+++ b/fk/secretsend.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/fluidkeys/crypto/openpgp"
 	"github.com/fluidkeys/crypto/openpgp/armor"
-	"github.com/fluidkeys/fluidkeys/api"
+	"github.com/fluidkeys/fluidkeys/apiclient"
 	"github.com/fluidkeys/fluidkeys/colour"
 	"github.com/fluidkeys/fluidkeys/out"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
@@ -40,7 +40,7 @@ import (
 func secretSend(recipientEmail string, filename string) exitCode {
 	armoredPublicKey, err := client.GetPublicKey(recipientEmail)
 	if err != nil {
-		if err == api.ErrPublicKeyNotFound {
+		if err == apiclient.ErrPublicKeyNotFound {
 			out.Print("\n")
 			out.Print("Couldn't find " + recipientEmail + " on Fluidkeys.\n\n")
 			out.Print("You can invite them to install Fluidkeys:\n")

--- a/fk/secretsend.go
+++ b/fk/secretsend.go
@@ -38,7 +38,7 @@ import (
 )
 
 func secretSend(recipientEmail string, filename string) exitCode {
-	armoredPublicKey, err := client.GetPublicKey(recipientEmail)
+	armoredPublicKey, err := api.GetPublicKey(recipientEmail)
 	if err != nil {
 		if err == apiclient.ErrPublicKeyNotFound {
 			out.Print("\n")
@@ -123,7 +123,7 @@ https://download.fluidkeys.com#` + recipientEmail + `
 		return 1
 	}
 
-	err = client.CreateSecret(pgpKey.Fingerprint(), encryptedSecret)
+	err = api.CreateSecret(pgpKey.Fingerprint(), encryptedSecret)
 	if err != nil {
 		printFailed("Couldn't send the secret to " + recipientEmail)
 		out.Print("Error: " + err.Error() + "\n")

--- a/fk/setup.go
+++ b/fk/setup.go
@@ -54,7 +54,7 @@ func setup(email string) exitCode {
 		return 1
 	}
 
-	err = client.CreateSecret(pgpKey.Fingerprint(), encryptedSecret)
+	err = api.CreateSecret(pgpKey.Fingerprint(), encryptedSecret)
 	if err != nil {
 		printFailed("Couldn't send a test secret to " + email)
 		out.Print("Error: " + err.Error() + "\n")

--- a/fk/teamapply.go
+++ b/fk/teamapply.go
@@ -37,7 +37,7 @@ func teamApply(teamUUID uuid.UUID) exitCode {
 		return code
 	}
 
-	teamName, err := client.GetTeamName(teamUUID)
+	teamName, err := api.GetTeamName(teamUUID)
 	if err != nil {
 		out.Print(ui.FormatFailure("Couldn't request to join team", nil, err))
 		return 1
@@ -167,7 +167,7 @@ func requestToJoinTeam(
 	if err := db.RecordRequestToJoinTeam(teamUUID, teamName, fingerprint, time.Now()); err != nil {
 		return err
 	}
-	if err := client.RequestToJoinTeam(teamUUID, fingerprint, email); err != nil {
+	if err := api.RequestToJoinTeam(teamUUID, fingerprint, email); err != nil {
 		return err
 	}
 	return nil

--- a/fk/teamauthorize.go
+++ b/fk/teamauthorize.go
@@ -57,7 +57,7 @@ func teamAuthorize() exitCode {
 
 		printHeader("Authorize requests to join " + myTeam.Name)
 
-		requests, err := client.ListRequestsToJoinTeam(myTeam.UUID, adminKey.Fingerprint())
+		requests, err := api.ListRequestsToJoinTeam(myTeam.UUID, adminKey.Fingerprint())
 		if err != nil {
 			out.Print(ui.FormatFailure("Error getting requests", nil, err))
 			return 1
@@ -102,7 +102,7 @@ func teamAuthorize() exitCode {
 		seenError := false
 
 		for _, request := range deleteRequests {
-			if err = client.DeleteRequestToJoinTeam(myTeam.UUID, request.UUID); err != nil {
+			if err = api.DeleteRequestToJoinTeam(myTeam.UUID, request.UUID); err != nil {
 				out.Print(ui.FormatWarning(
 					"Failed to delete a request to join the team", nil, err,
 				))

--- a/fk/teamcreate.go
+++ b/fk/teamcreate.go
@@ -203,7 +203,7 @@ func promptAndSignAndUploadRoster(t team.Team, key *pgpkey.PgpKey) (err error) {
 
 	ui.PrintCheckboxPending(checkboxSign)
 
-	if err := client.UpsertTeam(signedRoster, signature, privateKey.Fingerprint()); err != nil {
+	if err := api.UpsertTeam(signedRoster, signature, privateKey.Fingerprint()); err != nil {
 		rosterSaver.DiscardDraft()
 		return failUpload(err)
 	}

--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -123,7 +123,7 @@ func fetchAndUpdateRoster(t team.Team, unlockedKey *pgpkey.PgpKey, alwaysDownloa
 		}
 	}
 
-	roster, signature, err := client.GetTeamRoster(unlockedKey, t.UUID)
+	roster, signature, err := api.GetTeamRoster(unlockedKey, t.UUID)
 	if err != nil {
 		return nil, fmt.Errorf("error downloading team roster: %v", err)
 	}
@@ -187,7 +187,7 @@ func fetchAndSignTeamKeys(
 		}
 
 		err = ui.RunWithCheckboxes(person.Email, func() error {
-			key, err := client.GetPublicKeyByFingerprint(person.Fingerprint)
+			key, err := api.GetPublicKeyByFingerprint(person.Fingerprint)
 
 			if err != nil && err == apiclient.ErrPublicKeyNotFound {
 				log.Print(err)
@@ -259,7 +259,7 @@ func processRequestsToJoinTeam(unattended bool) (returnError error) {
 			continue
 		}
 
-		roster, signature, err := client.GetTeamRoster(unlockedKey, request.TeamUUID)
+		roster, signature, err := api.GetTeamRoster(unlockedKey, request.TeamUUID)
 
 		if err == apiclient.ErrForbidden {
 			printRequestHasntBeenApproved(request)
@@ -369,7 +369,7 @@ func discoverPublicKey(fingerprint fp.Fingerprint) (key *pgpkey.PgpKey, err erro
 		return key, nil
 	}
 
-	if key, err = client.GetPublicKeyByFingerprint(fingerprint); err != nil {
+	if key, err = api.GetPublicKeyByFingerprint(fingerprint); err != nil {
 		log.Printf("failed to find key %s in API: %v", fingerprint, err)
 	} else {
 		return key, nil

--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/fluidkeys/fluidkeys/api"
+	"github.com/fluidkeys/fluidkeys/apiclient"
 	"github.com/fluidkeys/fluidkeys/colour"
 	fp "github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/humanize"
@@ -189,7 +189,7 @@ func fetchAndSignTeamKeys(
 		err = ui.RunWithCheckboxes(person.Email, func() error {
 			key, err := client.GetPublicKeyByFingerprint(person.Fingerprint)
 
-			if err != nil && err == api.ErrPublicKeyNotFound {
+			if err != nil && err == apiclient.ErrPublicKeyNotFound {
 				log.Print(err)
 				return fmt.Errorf("Couldn't find key")
 			} else if err != nil {
@@ -261,7 +261,7 @@ func processRequestsToJoinTeam(unattended bool) (returnError error) {
 
 		roster, signature, err := client.GetTeamRoster(unlockedKey, request.TeamUUID)
 
-		if err == api.ErrForbidden {
+		if err == apiclient.ErrForbidden {
 			printRequestHasntBeenApproved(request)
 			continue // don't set returnError: this is an OK outcome
 		} else if err != nil {


### PR DESCRIPTION
1. rename `api` package to `apiclient`: it's not an api, it's a client of an API!

2. rename global `client` -> `api` in `fk/main.go`
   this allows the more natural feeling `api.GetPublicKey(..)`

3. rename `apiclient.NewClient` -> `apiclient.New`