### PR TITLE
Introduce launchd

### DIFF
--- a/fk/keymaintain.go
+++ b/fk/keymaintain.go
@@ -449,7 +449,7 @@ func tryMaintainAutomatically(fpr fpr.Fingerprint) error {
 	if err := Config.SetMaintainAutomatically(fpr, true); err != nil {
 		return err
 	}
-	if _, err := scheduler.Enable(nil); err != nil {
+	if _, err := scheduler.Enable(); err != nil {
 		return err
 	}
 	return nil

--- a/scheduler/cron.go
+++ b/scheduler/cron.go
@@ -1,0 +1,190 @@
+package scheduler
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+type cron struct{}
+
+// Enable writes Fluidkeys' cron lines into crontab
+func (c *cron) Enable() (crontabWasAdded bool, err error) {
+	crontab := &systemCrontab{}
+	return c.enable(crontab)
+}
+
+// Disable parses the crontab (output of `crontab -l`) and removes Fluidkeys'
+// cron lines if present.
+// If the remaining crontab is empty, the crontab is removed with `crontab -r`
+func (c *cron) Disable() (cronLinesWereRemoved bool, err error) {
+	crontab := &systemCrontab{}
+	return c.disable(crontab)
+}
+
+func (c *cron) Name() string {
+	return "crontab"
+}
+
+func (c *cron) enable(crontab runCrontabInterface) (crontabWasAdded bool, err error) {
+	currentCrontab, err := crontab.get()
+	if err != nil {
+		return false, fmt.Errorf("error getting crontab: %v", err)
+	}
+
+	if !hasFluidkeysCronLines(currentCrontab) {
+		newCrontab := addCrontabLinesWithoutRepeating(currentCrontab)
+		err = crontab.set(newCrontab)
+		if err != nil {
+			return false, ErrModifyingCrontab{origError: err}
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *cron) disable(crontab runCrontabInterface) (cronLinesWereRemoved bool, err error) {
+	currentCrontab, err := crontab.get()
+	if err != nil {
+		return false, fmt.Errorf("error getting crontab: %v", err)
+	}
+
+	if hasFluidkeysCronLines(currentCrontab) {
+		newCrontab := removeCrontabLines(currentCrontab)
+		err = crontab.set(newCrontab)
+
+		if err != nil {
+			return false, ErrModifyingCrontab{origError: err}
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func hasFluidkeysCronLines(crontab string) bool {
+	return strings.Contains(crontab, strings.TrimSuffix(CronLines, "\n"))
+}
+
+type systemCrontab struct{}
+
+func (s *systemCrontab) get() (string, error) {
+	output, err := s.runCrontab("-l")
+
+	if s.isNoCrontabError(output, err) {
+		return "", nil
+	}
+
+	return output, err
+}
+
+func (s *systemCrontab) set(newCrontab string) error {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		return fmt.Errorf("error opening temp file: %v", err)
+	}
+
+	if _, err := io.WriteString(f, newCrontab); err != nil {
+		return fmt.Errorf("error writing to temp file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("error closing temp file: %v", err)
+	}
+
+	if _, err := s.runCrontab(f.Name()); err != nil {
+		return fmt.Errorf("error updating crontab: %v", err)
+	}
+	return nil
+}
+
+// isNoCrontabError returns true if and only if the error looks like a failure from `crontab -l`
+// of the form "no crontab for foo"
+func (s *systemCrontab) isNoCrontabError(cronOutput string, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return isExitError(err) && strings.Contains(cronOutput, "no crontab for")
+}
+
+func isExitError(err error) bool {
+	if _, ok := err.(*exec.ExitError); ok {
+		return true
+	}
+	return false
+}
+
+func (*systemCrontab) runCrontab(arguments ...string) (string, error) {
+	log.Printf("Running `%s %s`", crontab, strings.Join(arguments, " "))
+	cmd := exec.Command(crontab, arguments...)
+
+	out, err := cmd.CombinedOutput()
+
+	outString := string(out)
+
+	if err != nil {
+		return outString, err
+	}
+	return outString, nil
+}
+
+func addCrontabLinesWithoutRepeating(crontab string) string {
+	removed := removeCrontabLines(crontab)
+
+	if !strings.HasSuffix(removed, "\n") {
+		// the crontab should always have a trailing newline
+		removed += "\n"
+	}
+
+	if isEmpty(removed) {
+		return CronLines
+	}
+
+	return removed + "\n" + CronLines
+}
+
+func removeCrontabLines(crontab string) string {
+	linesWithoutFinalNewline := strings.TrimSuffix(CronLines, "\n")
+	result := strings.Replace(crontab, linesWithoutFinalNewline, "", -1)
+
+	legacyWithoutFinalNewline := strings.TrimSuffix(legacyCronLines, "\n")
+	result = strings.Replace(result, legacyWithoutFinalNewline, "", -1)
+
+	if isEmpty(result) {
+		return ""
+	}
+	return strings.Trim(result, "\n") + "\n"
+}
+
+func isEmpty(crontab string) bool {
+	return strings.Trim(crontab, "\n") == ""
+}
+
+const crontab string = "crontab"
+
+// CronLines is the string Fluidkeys adds to a user's crontab to run itself
+const CronLines string = "# Fluidkeys added the following line to keep you and your team's keys updated\n" +
+	"# automatically with `fk sync`\n" +
+	"# To configure this, edit your config file (see `ffk --help` for the location)\n" +
+	"@hourly perl -e 'sleep int(rand(3600))' && /usr/local/bin/fk sync --cron-output\n"
+
+const legacyCronLines string = "# Fluidkeys added the following line. To disable, edit your " +
+	"Fluidkeys configuration file.\n" +
+	"@hourly /usr/local/bin/fk key maintain automatic --cron-output\n"
+
+// ErrModifyingCrontab is a custom error. It should be used to wrap any errors called during
+// Enable or Disable to ensure the caller knows how to present the user with the steps they
+// can take to manually recify the situation.
+type ErrModifyingCrontab struct {
+	origError error
+}
+
+func (e ErrModifyingCrontab) Error() string {
+	if e.origError.Error() != "" {
+		return e.origError.Error()
+	}
+	return "error modifying the crontab"
+}

--- a/scheduler/filehelpers.go
+++ b/scheduler/filehelpers.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Paul Furley and Ian Drysdale
+//
+// This file is part of Fluidkeys Client which makes it simple to use OpenPGP.
+//
+// Fluidkeys Client is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fluidkeys Client is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Fluidkeys Client.  If not, see <https://www.gnu.org/licenses/>.
+
+package scheduler
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+type fileFunctionsInterface interface {
+	OsRemove(string) error                                   // like os.Remove
+	OsStat(string) (os.FileInfo, error)                      // like os.Stat
+	IoutilWriteFile(string, []byte, os.FileMode) (int error) // like ioutil.WriteFile
+}
+
+// fileFunctionsPassthrough simply passes calls through to the real os/io/ioutil
+// function
+type fileFunctionsPassthrough struct {
+}
+
+func (p *fileFunctionsPassthrough) OsRemove(filename string) error {
+	return os.Remove(filename)
+}
+
+func (p *fileFunctionsPassthrough) OsStat(filename string) (os.FileInfo, error) {
+	return os.Stat(filename)
+}
+
+func (p *fileFunctionsPassthrough) IoutilWriteFile(filename string, data []byte, mode os.FileMode) (int error) {
+	return ioutil.WriteFile(filename, data, mode)
+}

--- a/scheduler/interfaces.go
+++ b/scheduler/interfaces.go
@@ -4,3 +4,8 @@ type runCrontabInterface interface {
 	get() (string, error)
 	set(newCrontab string) error
 }
+
+type runLaunchctlInterface interface {
+	load(filename string) (string, error)
+	remove(label string) (string, error)
+}

--- a/scheduler/launchd.go
+++ b/scheduler/launchd.go
@@ -1,0 +1,163 @@
+package scheduler
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+type launchd struct{}
+
+// Enable creates the launchd script and then loads it using launchctl
+func (ld *launchd) Enable() (launchdWasLoaded bool, err error) {
+	launchctl := &systemLaunchctl{}
+	launchdFilename, err := ld.getFilename()
+	if err != nil {
+		return false, err
+	}
+
+	return ld.enable(launchctl, &fileFunctionsPassthrough{}, launchdFilename)
+}
+
+// Disable deletes the .plist file, then removes the launchd script
+func (ld *launchd) Disable() (launchdWasRemoved bool, err error) {
+	launchctl := &systemLaunchctl{}
+	launchdFilename, err := ld.getFilename()
+	if err != nil {
+		return false, err
+	}
+
+	return ld.disable(launchctl, &fileFunctionsPassthrough{}, launchdFilename, launchdLabel)
+}
+
+func (ld *launchd) Name() string {
+	return "launchd"
+}
+
+func (ld *launchd) enable(
+	launchctl runLaunchctlInterface,
+	fileFunctions fileFunctionsInterface,
+	launchdAgentFilename string) (
+	launchdFileWasCreated bool, err error) {
+
+	if exists, err := fileExists(fileFunctions, launchdAgentFilename); !exists || err != nil {
+		// file does not exist (or couldn't tell), try writing out default launchd agent file
+		if err = fileFunctions.IoutilWriteFile(
+			launchdAgentFilename, []byte(LaunchdFileContents), 0600); err != nil {
+			return false,
+				fmt.Errorf("%s didn't exist and failed to create it: %v", launchdAgentFilename, err)
+		}
+	}
+
+	_, err = launchctl.load(launchdAgentFilename)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func fileExists(fileFunctions fileFunctionsInterface, filename string) (exists bool, err error) {
+	_, err = fileFunctions.OsStat(filename)
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (ld *launchd) disable(
+	launchctl runLaunchctlInterface,
+	fileFunctions fileFunctionsInterface,
+	launchdAgentFilename string,
+	launchdLabel string,
+) (
+	launchdFileWasRemoved bool, err error) {
+
+	if err := fileFunctions.OsRemove(launchdAgentFilename); err != nil {
+		return false, fmt.Errorf("failed to remove %s: %v", launchdAgentFilename, err)
+	}
+
+	// Note: if we call this function from launchd the following line will execture, but
+	// then terminate immediately (as it's been unloaded). This means that no further code will run.
+	_, err = launchctl.remove(launchdLabel)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (ld *launchd) getFilename() (string, error) {
+	homeDirectory, err := homedir.Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return path.Join(homeDirectory, "Library", "LaunchAgents", launchdFile), nil
+}
+
+type systemLaunchctl struct{}
+
+func (s *systemLaunchctl) load(agentFilename string) (output string, err error) {
+	return s.runLaunchctl("load", agentFilename)
+}
+
+func (s *systemLaunchctl) remove(agentFilename string) (output string, err error) {
+	return s.runLaunchctl("remove", launchdLabel)
+}
+
+func (s *systemLaunchctl) runLaunchctl(verb string, filename string) (string, error) {
+	log.Printf("Running `%s %s %s`", launchctl, verb, filename)
+	cmd := exec.Command(launchctl, verb, filename)
+
+	out, err := cmd.CombinedOutput()
+
+	outString := string(out)
+	if err != nil {
+		log.Printf("launchd failed (output follows) %v\n%s", err, outString)
+		return outString, err
+	}
+	// If launchd can't find a file, it returns a string similiar to
+	//    directory/nonexistant.plist: No such file or directory
+	// but exits with code 0 and no error.
+	if strings.Contains(outString, "No such file or directory") {
+		return outString, errCouldntFindLaunchdFile
+	}
+	return outString, nil
+}
+
+const (
+	// LaunchdFileContents is the agent file for running fk sync every 60 minutes
+	LaunchdFileContents = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>` + launchdLabel + `</string>
+        <key>ProgramArguments</key>
+        <array>
+            <string>/usr/local/bin/fk</string>
+            <string>sync</string>
+            <string>--cron-output</string>
+        </array>
+        <key>StartInterval</key>
+        <integer>3600</integer>
+    </dict>
+</plist>
+`
+	launchctl    = "launchctl"
+	launchdLabel = "com.fluidkeys.fk.sync"
+	launchdFile  = "com.fluidkeys.fk.sync.plist"
+)
+
+var (
+	errCouldntFindLaunchdFile = errors.New("couldn't find launchd file")
+)

--- a/scheduler/launchd_test.go
+++ b/scheduler/launchd_test.go
@@ -1,0 +1,147 @@
+package scheduler
+
+import (
+	"os"
+	"testing"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+)
+
+var ld = launchd{}
+
+func TestLaunchdEnable(t *testing.T) {
+	t.Run("runs `launchctl load` if agent file is present", func(t *testing.T) {
+		mockFileHelper := mockFileFunctions{
+			OsStatReturnError:          nil,
+			IoutilWriteFileReturnError: nil,
+		}
+		mockLaunchctl := &mockLaunchctl{}
+
+		launchdEnabled, err := ld.enable(mockLaunchctl, &mockFileHelper, "fake.plist")
+		assert.NoError(t, err)
+
+		assert.Equal(t, true, launchdEnabled)
+		assert.Equal(t, true, mockLaunchctl.loadCalled)
+	})
+
+	t.Run("creates agent file if it's missing", func(t *testing.T) {
+		mockFileHelper := mockFileFunctions{
+			OsStatReturnError:          os.ErrNotExist,
+			IoutilWriteFileReturnError: nil,
+		}
+		mockLaunchctl := &mockLaunchctl{}
+
+		launchdEnabled, err := ld.enable(mockLaunchctl, &mockFileHelper, "fake.plist")
+		assert.NoError(t, err)
+
+		assert.Equal(t, LaunchdFileContents, string(mockFileHelper.IoutilWriteFileGotData))
+		assert.Equal(t, os.FileMode(0600), mockFileHelper.IoutilWriteFileGotMode)
+
+		t.Run("then runs `launchctl load`", func(t *testing.T) {
+			assert.Equal(t, true, launchdEnabled)
+			assert.Equal(t, true, mockLaunchctl.loadCalled)
+		})
+	})
+
+	t.Run("errors if file is missing and couldn't be created due to permission error",
+		func(t *testing.T) {
+			mockFileHelper := mockFileFunctions{
+				OsStatReturnError:          os.ErrNotExist,
+				IoutilWriteFileReturnError: os.ErrPermission,
+			}
+			mockLaunchctl := &mockLaunchctl{}
+
+			launchdEnabled, err := ld.enable(mockLaunchctl, &mockFileHelper, "fake.plist")
+			assert.GotError(t, err)
+			assert.Equal(t,
+				"fake.plist didn't exist and failed to create it: permission denied",
+				err.Error(),
+			)
+
+			assert.Equal(t, false, launchdEnabled)
+			assert.Equal(t, false, mockLaunchctl.loadCalled)
+		})
+}
+
+func TestLaunchdDisable(t *testing.T) {
+	t.Run("unload and deletes successfully if file is removed", func(t *testing.T) {
+		mockFileHelper := mockFileFunctions{
+			OsRemoveReturnError: nil,
+		}
+		mockLaunchctl := &mockLaunchctl{}
+
+		launchdDisabled, err := ld.disable(mockLaunchctl, &mockFileHelper, "fake.plist", "fake")
+		assert.NoError(t, err)
+
+		assert.Equal(t, true, launchdDisabled)
+		assert.Equal(t, "fake", mockLaunchctl.removeCalledFor)
+	})
+
+	t.Run("error if file couldn't be removed", func(t *testing.T) {
+		mockFileHelper := mockFileFunctions{
+			OsRemoveReturnError: os.ErrPermission,
+		}
+		mockLaunchctl := &mockLaunchctl{}
+
+		launchdDisabled, err := ld.disable(mockLaunchctl, &mockFileHelper, "fake.plist", "fake")
+		assert.GotError(t, err)
+		assert.Equal(t,
+			"failed to remove fake.plist: permission denied",
+			err.Error(),
+		)
+
+		assert.Equal(t, false, launchdDisabled)
+		assert.Equal(t, false, mockLaunchctl.removeCalled)
+	})
+}
+
+type mockFileFunctions struct {
+	// provides fake versions of os.Stat etc.
+	// implements fileFunctionsInterface
+	OsRemoveReturnError        error
+	OsRemoveCalledWithFilename string
+	OsStatReturnError          error
+	IoutilWriteFileReturnError error
+
+	// IoutilWriteFileGotData stores whatever data was was writeen to WriteFile()
+	IoutilWriteFileGotData []byte
+	IoutilWriteFileGotMode os.FileMode
+}
+
+func (m *mockFileFunctions) OsRemove(filename string) error {
+	m.OsRemoveCalledWithFilename = filename
+	return m.OsRemoveReturnError
+}
+
+func (m *mockFileFunctions) OsStat(filename string) (os.FileInfo, error) {
+	return nil, m.OsStatReturnError
+}
+
+func (m *mockFileFunctions) IoutilWriteFile(filename string, data []byte, mode os.FileMode) (int error) {
+	m.IoutilWriteFileGotData = data
+	m.IoutilWriteFileGotMode = mode
+
+	return m.IoutilWriteFileReturnError
+}
+
+type mockLaunchctl struct {
+	loadResult   string
+	loadError    error
+	removeResult string
+	removeError  error
+
+	loadCalled      bool
+	removeCalled    bool
+	removeCalledFor string
+}
+
+func (m *mockLaunchctl) load(filename string) (string, error) {
+	m.loadCalled = true
+	return m.loadResult, m.loadError
+}
+
+func (m *mockLaunchctl) remove(label string) (string, error) {
+	m.removeCalled = true
+	m.removeCalledFor = label
+	return m.removeResult, m.removeError
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -17,170 +17,34 @@
 
 package scheduler
 
-import (
-	"fmt"
-	"io"
-	"io/ioutil"
-	"log"
-	"os/exec"
-	"strings"
-)
+var scheduler schedulerInterface
 
-// Enable adds cron lines to the user's crontab and returns whether the
-// crontab was updated.
-func Enable(crontab runCrontabInterface) (crontabWasAdded bool, err error) {
-	if crontab == nil {
-		crontab = &systemCrontab{}
-	}
-
-	currentCrontab, err := crontab.get()
-	if err != nil {
-		return false, fmt.Errorf("error getting crontab: %v", err)
-	}
-
-	if !hasFluidkeysCronLines(currentCrontab) {
-		newCrontab := addCrontabLinesWithoutRepeating(currentCrontab)
-		err = crontab.set(newCrontab)
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-
-	return false, nil
+func init() {
+	scheduler = &cron{}
 }
 
-// Disable parses the crontab (output of `crontab -l`) and removes Fluidkeys'
-// cron lines if present.
-// If the remaining crontab is empty, the crontab is removed with `crontab -r`
-func Disable(crontab runCrontabInterface) (cronLinesWereRemoved bool, err error) {
-	if crontab == nil {
-		crontab = &systemCrontab{}
-	}
-
-	currentCrontab, err := crontab.get()
-	if err != nil {
-		return false, fmt.Errorf("error getting crontab: %v", err)
-	}
-
-	if hasFluidkeysCronLines(currentCrontab) {
-		newCrontab := removeCrontabLines(currentCrontab)
-		err = crontab.set(newCrontab)
-
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-	return false, nil
+// Enable schedules Fluidkeys sync task to run regularly
+func Enable() (bool, error) {
+	return scheduler.Enable()
 }
 
-func hasFluidkeysCronLines(crontab string) bool {
-	return strings.Contains(crontab, strings.TrimSuffix(CronLines, "\n"))
+// Disable stops Fluidkeys sync task from running regularly
+func Disable() (bool, error) {
+	return scheduler.Disable()
 }
 
-type systemCrontab struct{}
-
-func (s *systemCrontab) get() (string, error) {
-	output, err := s.runCrontab("-l")
-
-	if s.isNoCrontabError(output, err) {
-		return "", nil
-	}
-
-	return output, err
+// Name returns a friendly name for the scheduler
+func Name() string {
+	return scheduler.Name()
 }
 
-func (s *systemCrontab) set(newCrontab string) error {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		return fmt.Errorf("error opening temp file: %v", err)
-	}
-
-	if _, err := io.WriteString(f, newCrontab); err != nil {
-		return fmt.Errorf("error writing to temp file: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("error closing temp file: %v", err)
-	}
-
-	if _, err := s.runCrontab(f.Name()); err != nil {
-		return fmt.Errorf("error updating crontab: %v", err)
-	}
-	return nil
+// schedulerInterface provides the uniform interface for scheduling a task on the
+// operating system
+type schedulerInterface interface {
+	// Enable turns on scheduling with the given interface
+	Enable() (bool, error)
+	// Disable turns off scheduling with the given interface
+	Disable() (bool, error)
+	// Name returns a friendly name for the scheduler
+	Name() string
 }
-
-// isNoCrontabError returns true if and only if the error looks like a failure from `crontab -l`
-// of the form "no crontab for foo"
-func (s *systemCrontab) isNoCrontabError(cronOutput string, err error) bool {
-	if err == nil {
-		return false
-	}
-
-	return isExitError(err) && strings.Contains(cronOutput, "no crontab for")
-}
-
-func isExitError(err error) bool {
-	if _, ok := err.(*exec.ExitError); ok {
-		return true
-	}
-	return false
-}
-
-func (*systemCrontab) runCrontab(arguments ...string) (string, error) {
-	log.Printf("Running `%s %s`", crontab, strings.Join(arguments, " "))
-	cmd := exec.Command(crontab, arguments...)
-
-	out, err := cmd.CombinedOutput()
-
-	outString := string(out)
-
-	if err != nil {
-		return outString, err
-	}
-	return outString, nil
-}
-
-func addCrontabLinesWithoutRepeating(crontab string) string {
-	removed := removeCrontabLines(crontab)
-
-	if !strings.HasSuffix(removed, "\n") {
-		// the crontab should always have a trailing newline
-		removed += "\n"
-	}
-
-	if isEmpty(removed) {
-		return CronLines
-	}
-
-	return removed + "\n" + CronLines
-}
-
-func removeCrontabLines(crontab string) string {
-	linesWithoutFinalNewline := strings.TrimSuffix(CronLines, "\n")
-	result := strings.Replace(crontab, linesWithoutFinalNewline, "", -1)
-
-	legacyWithoutFinalNewline := strings.TrimSuffix(legacyCronLines, "\n")
-	result = strings.Replace(result, legacyWithoutFinalNewline, "", -1)
-
-	if isEmpty(result) {
-		return ""
-	}
-	return strings.Trim(result, "\n") + "\n"
-}
-
-func isEmpty(crontab string) bool {
-	return strings.Trim(crontab, "\n") == ""
-}
-
-const crontab string = "crontab"
-
-// CronLines is the string Fluidkeys adds to a user's crontab to run itself
-const CronLines string = "# Fluidkeys added the following line to keep you and your team's keys updated\n" +
-	"# automatically with `fk sync`\n" +
-	"# To configure this, edit your config file (see `ffk --help` for the location)\n" +
-	"@hourly perl -e 'sleep int(rand(3600))' && /usr/local/bin/fk sync --cron-output\n"
-
-const legacyCronLines string = "# Fluidkeys added the following line. To disable, edit your " +
-	"Fluidkeys configuration file.\n" +
-	"@hourly /usr/local/bin/fk key maintain automatic --cron-output\n"

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -17,10 +17,17 @@
 
 package scheduler
 
+import "os/exec"
+
 var scheduler schedulerInterface
 
 func init() {
-	scheduler = &cron{}
+	_, err := exec.LookPath(launchctl)
+	if err != nil {
+		scheduler = &cron{}
+	} else {
+		scheduler = &launchd{}
+	}
 }
 
 // Enable schedules Fluidkeys sync task to run regularly


### PR DESCRIPTION
I made a schedulerInterface and seperated out cron and launchd.

We check for `launchd` in the init() of the scheduler package
to figure out whether to pass through to launchd or cron.