### PR TITLE
enable re-joining a team you've deleted

### DIFF
--- a/fk/teamapply.go
+++ b/fk/teamapply.go
@@ -187,8 +187,6 @@ func ensureNoExistingRequests(
 		lines :=
 			[]string{
 				formatYouRequestedToJoin(*existingRequest),
-				"Check if the team admin has authorized your request by running " +
-					colour.Cmd("fk team fetch"),
 				"",
 				"Here are the verification details for your team admin:",
 				"",
@@ -198,6 +196,8 @@ func ensureNoExistingRequests(
 			// db, so that option isn't available. I don't believe this affects the verification
 			// but it could lead to a confusing state.
 		lines = append(lines, formatVerificationLines(existingRequest.Fingerprint, email)...)
+		lines = append(lines, "", "Check if the team admin has authorized your request by running "+
+			colour.Cmd("fk team fetch"))
 		out.Print(ui.FormatWarning(
 			"You've already requested to join "+existingRequest.TeamName, lines, nil))
 		return 1


### PR DESCRIPTION
if you've trashed your `teams/team` subdirectory, previously it was difficult to rejoin a team.

Assumption: you're listed in the team roster on the API.

Scenarios:

1. no requests to join team in local DB or in API
2. got a request to join team in local DB but *not* in the API
3. no request to join team in local DB but *got one* in the API
4. got request to join team in local DB and in the API


If you've got a local request already, it presents an infobox with your verification details
you need to give the admin.

For this scenario the solution is running `fk team fetch`. I've moved the call to action (run `fk
team fetch`) to the bottom so it's clearer.


tricker because the API rejects your request to join the team, saying
'Failed to apply: Already got request'

Now, we store a request in the db, ask the API if we're already in the team, and if so,
pass straight off to `fk team fetch`, which will pick up the request from the db and join the
team.

We skips requesting to join in the API, so don't hit that issue.


As with 3, we store a local request, ask the API, then pass straight through to `fk team fetch`