### PR TITLE
Instruct to allow keychain access

### DIFF
--- a/fk/keycreate.go
+++ b/fk/keycreate.go
@@ -183,6 +183,16 @@ func keyCreate(email string) (exitCode, *pgpkey.PgpKey) {
 		ui.PrintCheckboxFailure("Store password in "+Keyring.Name(), err)
 	}
 
+	ui.PrintCheckboxPending("Read back password from " + Keyring.Name() +
+		" " + Keyring.PermissionsInstructions())
+	_, gotPassword := Keyring.LoadPassword(generateJob.pgpKey.Fingerprint())
+	if gotPassword == true {
+		ui.PrintCheckboxSuccess("Read back password from " + Keyring.Name())
+	} else {
+		ui.PrintCheckboxFailure("Read back password from "+Keyring.Name(),
+			fmt.Errorf("automatic maintenance won't work"))
+	}
+
 	ui.PrintCheckboxPending("Automatically rotate key each month using cron")
 
 	if err := tryMaintainAutomatically(generateJob.pgpKey.Fingerprint()); err == nil {

--- a/fk/keymaintain.go
+++ b/fk/keymaintain.go
@@ -345,6 +345,21 @@ func promptAndTurnOnMaintainAutomatically(prompter promptYesNoInterface, keyTask
 	out.Print("This requires storing the password in the system keyring.\n\n")
 
 	if prompter.promptYesNo(promptMaintainAutomatically, "", keyTask.key) == true {
+
+		out.Print("Fluidkeys must be able to read back the password from " +
+			Keyring.Name() + "\n")
+		if Keyring.PermissionsInstructions() != "" {
+			out.Print(Keyring.PermissionsInstructions() + "\n\n")
+		}
+
+		_, gotPassword := Keyring.LoadPassword(keyTask.key.Fingerprint())
+		if gotPassword == true {
+			printSuccess("Read back password from " + Keyring.Name())
+		} else {
+			printFailed("Failed to read back password from " + Keyring.Name())
+			return
+		}
+
 		if err := tryStorePassword(keyTask.key.Fingerprint(), keyTask.password); err == nil {
 			printSuccess("Stored password in " + Keyring.Name())
 		} else {

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/fluidkeys/fluidkeys/colour"
 	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
 	externalkeyring "github.com/fluidkeys/keyring"
 )
@@ -141,6 +142,15 @@ func (k *Keyring) Name() string {
 	default:
 		return "system keyring"
 	}
+}
+
+// PermissionsInstructions returns the instructions a user should follow to grant Fluidkeys to
+// access the system's keyring
+func (k Keyring) PermissionsInstructions() string {
+	if externalkeyring.KeychainBackend == k.backendType {
+		return "(Select '" + colour.Info("Always Allow") + "')"
+	}
+	return ""
 }
 
 func (k *Keyring) noBackend() bool {


### PR DESCRIPTION
We do this on both `key create` and `key from-gpg`, but only if the keyring
backend is KeyChain.

This is how it looks on macOS.

For *key create*:
![Screenshot 2019-05-03 at 15 18 57](https://user-images.githubusercontent.com/55195/57143722-6dcb6600-6db7-11e9-9a13-66dfa30dc7ce.png)

For *key maintain*:
![Screenshot 2019-05-03 at 15 20 29](https://user-images.githubusercontent.com/55195/57143735-73c14700-6db7-11e9-9df5-4efd8e9c340d.png)
