### PR TITLE
on launchd enable, notify before editing crontab

### DIFF
--- a/scheduler/cron.go
+++ b/scheduler/cron.go
@@ -65,6 +65,18 @@ func (c *cron) disable(crontab runCrontabInterface) (cronLinesWereRemoved bool, 
 	return false, nil
 }
 
+func (c *cron) IsEnabled() (enabled bool, err error) {
+	return c.isEnabled(&systemCrontab{})
+}
+
+func (c *cron) isEnabled(crontab runCrontabInterface) (enabled bool, err error) {
+	currentCrontab, err := crontab.get()
+	if err != nil {
+		return false, fmt.Errorf("error getting crontab: %v", err)
+	}
+	return hasFluidkeysCronLines(currentCrontab), nil
+}
+
 func hasFluidkeysCronLines(crontab string) bool {
 	return strings.Contains(crontab, strings.TrimSuffix(CronLines, "\n"))
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -90,6 +90,7 @@ func tryDisableCrontab() {
 	if err != nil {
 		out.Print("To remove Fluidkeys from crontab manually, see:\n")
 		out.Print("https://www.fluidkeys.com/docs/remove-crontab-lines-macos-mojave/\n")
+		out.Print("\n")
 	}
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -20,6 +20,9 @@ package scheduler
 import (
 	"log"
 	"os/exec"
+
+	"github.com/fluidkeys/fluidkeys/out"
+	"github.com/fluidkeys/fluidkeys/ui"
 )
 
 var scheduler schedulerInterface
@@ -61,11 +64,32 @@ func Name() string {
 func tryDisableCrontab() {
 	c := cron{}
 
-	wasDisabled, err := c.Disable()
+	enabled, err := c.IsEnabled()
 	if err != nil {
-		log.Printf("failed to disable crontab (migrating to launchd): %v", err)
-	} else if wasDisabled {
-		log.Printf("disabled Fluidkeys in crontab")
+		log.Printf("failed to check crontab (migrating to launchd): %v", err)
+		return
+	} else if !enabled {
+		return
+	}
+
+	out.Print("Fluidkeys no longer uses cron to run in the background.\n")
+	out.Print("Removing leftover lines from crontab.\n\n")
+
+	err = ui.RunWithCheckboxes("edit crontab to remove Fluidkeys lines", func() error {
+		wasDisabled, err := c.Disable()
+
+		if err != nil {
+			log.Printf("failed to disable crontab (migrating to launchd): %v", err)
+		} else if wasDisabled {
+			log.Printf("disabled Fluidkeys in crontab")
+		}
+		return err
+	})
+	out.Print("\n")
+
+	if err != nil {
+		out.Print("To remove Fluidkeys from crontab manually, see:\n")
+		out.Print("https://www.fluidkeys.com/docs/remove-crontab-lines-macos-mojave/\n")
 	}
 }
 


### PR DESCRIPTION
if we've just enabled launchd for the first time, we try and remove legacy
crontab lines.

If and only if the cron lines were actually present, print a permissions
primer and checkbox before trying to remove them.

This prevents the situation where someone types `fk` and all they see is a
permissions dialog asking to "administer the computer". At least they'll
get some heads-up about why.