### PR TITLE
team fetch: don't continue if failed to fetch key

### DIFF
--- a/fk/teamfetch.go
+++ b/fk/teamfetch.go
@@ -210,6 +210,9 @@ func fetchAndCertifyTeamKeys(
 			}
 			return nil
 		})
+		if err != nil {
+			continue
+		}
 
 		err = ui.RunWithCheckboxes(person.Email+": sign key", func() error {
 


### PR DESCRIPTION
fail more gracefully than a nil pointer error

https://github.com/fluidkeys/fluidkeys/issues/502

this bug was introduced in 451c6182f698b5a0a7ef6dd81480e358c9ecc364

![image](https://user-images.githubusercontent.com/254290/57445283-e2842180-7249-11e9-9664-276a8c7b5095.png)
