### PR TITLE
`team apply`: don't get stuck unable to join a team

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -334,7 +334,7 @@ func (db Database) saveToFile(message Message) error {
 
 // deduplicateRequests returns a de-duplicated version of requests, where a duplicate is defined
 // as having the same (TeamUUID + Fingerprint) pair.
-// The *oldest* RequestedAt defines the single request that's returned.
+// The *newest* RequestedAt defines the single request that's returned.
 func deduplicateRequests(requests []RequestToJoinTeamMessage) (deduped []RequestToJoinTeamMessage) {
 	mapHash := func(r RequestToJoinTeamMessage) string {
 		return fmt.Sprintf("%s%s", r.TeamUUID, r.Fingerprint)
@@ -353,11 +353,11 @@ func deduplicateRequests(requests []RequestToJoinTeamMessage) (deduped []Request
 	}
 
 	for _, dupeRequests := range reqsMap {
-		sort.Sort(earliestFirst(dupeRequests))
+		sort.Sort(newestFirst(dupeRequests))
 		deduped = append(deduped, dupeRequests[0] /* 0th is the earliest */)
 	}
 
-	sort.Sort(earliestFirst(deduped))
+	sort.Sort(newestFirst(deduped))
 	return deduped
 }
 

--- a/database/sort.go
+++ b/database/sort.go
@@ -1,9 +1,9 @@
 package database
 
-// earliestFirst implements sort.Interface for []RequestToJoinTeamMessage based on
+// newestFirst implements sort.Interface for []RequestToJoinTeamMessage based on
 // the RequestedAt field.
-type earliestFirst []RequestToJoinTeamMessage
+type newestFirst []RequestToJoinTeamMessage
 
-func (a earliestFirst) Len() int           { return len(a) }
-func (a earliestFirst) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a earliestFirst) Less(i, j int) bool { return a[i].RequestedAt.Before(a[j].RequestedAt) }
+func (a newestFirst) Len() int           { return len(a) }
+func (a newestFirst) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a newestFirst) Less(i, j int) bool { return a[i].RequestedAt.After(a[j].RequestedAt) }

--- a/fk/teamapply.go
+++ b/fk/teamapply.go
@@ -68,6 +68,14 @@ func teamApply(teamUUID uuid.UUID) exitCode {
 
 	} else if alreadyInTeam {
 		fmt.Printf("You're already in the team. Running " + colour.Cmd("fk team fetch") + "\n")
+
+		// create a "fake" request to join the team, so that `team fetch` can process it
+		if err := db.RecordRequestToJoinTeam(
+			teamUUID, teamName, pgpKey.Fingerprint(), time.Now()); err != nil {
+			out.Print(ui.FormatFailure("Failed to apply to join "+teamName, nil, err))
+			return 1
+		}
+
 		return teamFetch(false)
 	}
 


### PR DESCRIPTION
previously it was possible that the local DB has a request to join a team, but the API doesn't

that makes it impossible to re-request to join the team, *and* for an admin to authorize the person

these changes:
1. make it less likely the mismatch will occur in the first place
2. make it recoverable if that does occur