### PR TITLE
add team.ValidateUpdate(before, after, me)

### DIFF
--- a/team/team.go
+++ b/team/team.go
@@ -182,6 +182,10 @@ func (t *Team) Validate() error {
 		fingerprintsSeen[person.Fingerprint] = true
 	}
 
+	if len(t.People) == 0 {
+		return fmt.Errorf("team has no members")
+	}
+
 	if len(t.Admins()) == 0 {
 		return fmt.Errorf("team has no administrators")
 	}

--- a/team/team.go
+++ b/team/team.go
@@ -202,6 +202,16 @@ func (t Team) IsAdmin(fingerprint fpr.Fingerprint) bool {
 	return false
 }
 
+// Contains returns whether the given fingerprint is a member of the team
+func (t Team) Contains(fingerprint fpr.Fingerprint) bool {
+	for _, person := range t.People {
+		if person.Fingerprint == fingerprint {
+			return true
+		}
+	}
+	return false
+}
+
 // GetPersonForFingerprint takes a fingerprint and returns the person in the team with the
 // matching fingperint.
 func (t *Team) GetPersonForFingerprint(fingerprint fpr.Fingerprint) (*Person, error) {

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -376,6 +376,17 @@ func TestValidate(t *testing.T) {
 			"AAAA BBBB AAAA BBBB AAAA  AAAA BBBB AAAA BBBB AAAA"), err)
 	})
 
+	t.Run("with no members", func(t *testing.T) {
+		team := Team{
+			Name:   "Kiffix",
+			UUID:   uuid.Must(uuid.NewV4()),
+			People: []Person{},
+		}
+
+		err := team.Validate()
+		assert.Equal(t, fmt.Errorf("team has no members"), err)
+	})
+
 	t.Run("with no admins", func(t *testing.T) {
 		team := Team{
 			Name: "Kiffix",

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -471,6 +471,35 @@ func TestIsAdmin(t *testing.T) {
 	})
 }
 
+func TestTeamContains(t *testing.T) {
+	pesonInTeam := Person{
+		Email:       "admin@example.com",
+		Fingerprint: fpr.MustParse("AAAABBBBAAAABBBBAAAAAAAABBBBAAAABBBBAAAA"),
+	}
+	personNotInTeam := Person{
+		Email:       "normal@example.com",
+		Fingerprint: fpr.MustParse("CCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDDCCCCDDDD"),
+	}
+
+	team := Team{
+		Name:   "Kiffix",
+		UUID:   uuid.Must(uuid.NewV4()),
+		People: []Person{pesonInTeam},
+	}
+
+	t.Run("team.Contains returns true for person in the team", func(t *testing.T) {
+		got := team.Contains(pesonInTeam.Fingerprint)
+
+		assert.Equal(t, true, got)
+	})
+
+	t.Run("team.Contains returns false for person not in the team", func(t *testing.T) {
+		got := team.Contains(personNotInTeam.Fingerprint)
+
+		assert.Equal(t, false, got)
+	})
+}
+
 func TestGetPersonForFingerprint(t *testing.T) {
 	personOne := Person{
 		Email:       "test@example.com",

--- a/team/validateupdate.go
+++ b/team/validateupdate.go
@@ -1,0 +1,83 @@
+package team
+
+import "fmt"
+
+// ValidateUpdate tests whether the given changes to a team are OK
+func ValidateUpdate(before *Team, after *Team, me *Person) error {
+	// validate the team UUID didn't change
+	// team name can't change
+	// can't change the email for a given key
+	// how to handle email address changes? deny them?
+	// don't allow people to be arbitrarily added (I think)
+	// email address appears twice
+	// fingerprint appears twice
+	// I can't remove myself from a team
+	// I can't demote myself as an admin (another admin must promote)
+	// factor out before/after tests from API?
+	// validate that there's still a team admin
+	// protect against replay attacks: prevent someone from uploading an old (signed) version of the file
+	// signing key's fingerprint missing from roster
+	// signing key isn't listed in roster
+	// signing key listed in roster but not an admin
+
+	if err := after.Validate(); err != nil {
+		return err
+	}
+
+	if err := validateTeamUUID(before, after); err != nil {
+		return err
+	}
+
+	if err := validateTeamNameCantChange(before, after); err != nil {
+		return err
+	}
+
+	if err := validateIAmAdmin(before, after, me); err != nil {
+		return err
+	}
+
+	if err := validateCannotRemoveSelf(before, after, me); err != nil {
+		return err
+	}
+
+	if err := validateCannotDemoteSelfAsAdmin(before, after, me); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateTeamUUID(before, after *Team) error {
+	if before.UUID != after.UUID {
+		return fmt.Errorf("team UUID cannot be changed")
+	}
+	return nil
+}
+
+func validateTeamNameCantChange(before, after *Team) error {
+	if before.Name != after.Name {
+		return fmt.Errorf("team name cannot currently be changed")
+	}
+	return nil
+}
+
+func validateIAmAdmin(before, after *Team, me *Person) error {
+	if !before.IsAdmin(me.Fingerprint) {
+		return fmt.Errorf("you're not a team admin")
+	}
+	return nil
+}
+
+func validateCannotRemoveSelf(before, after *Team, me *Person) error {
+	if !after.Contains(me.Fingerprint) {
+		return fmt.Errorf("can't remove yourself from the team")
+	}
+	return nil
+}
+
+func validateCannotDemoteSelfAsAdmin(before, after *Team, me *Person) error {
+	if !after.IsAdmin(me.Fingerprint) {
+		return fmt.Errorf("can't demote yourself as team admin")
+	}
+	return nil
+}

--- a/team/validateupdate_test.go
+++ b/team/validateupdate_test.go
@@ -1,0 +1,177 @@
+package team
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+	"github.com/fluidkeys/fluidkeys/exampledata"
+	"github.com/gofrs/uuid"
+)
+
+func TestValidateUpate(t *testing.T) {
+	tina := Person{
+		Email:       "tina@example.com",
+		Fingerprint: exampledata.ExampleFingerprint2,
+		IsAdmin:     true,
+	}
+
+	chat := Person{
+		Email:       "chat@example.com",
+		Fingerprint: exampledata.ExampleFingerprint3,
+		IsAdmin:     false,
+	}
+
+	chatAdmin := Person{
+		Email:       "chat@example.com",
+		Fingerprint: exampledata.ExampleFingerprint3,
+		IsAdmin:     true,
+	}
+
+	mark := Person{
+		Email:       "mark@example.com",
+		Fingerprint: exampledata.ExampleFingerprint4,
+		IsAdmin:     false,
+	}
+
+	team := Team{
+		UUID:   uuid.Must(uuid.NewV4()),
+		Name:   "Test team",
+		People: []Person{tina, chat},
+	}
+
+	t.Run("a team member can be removed", func(t *testing.T) {
+		updatedTeam := team
+		updatedTeam.People = []Person{tina, chat, mark}
+
+		assert.NoError(t, ValidateUpdate(&team, &updatedTeam, &tina))
+	})
+
+	t.Run("a team member can be removed", func(t *testing.T) {
+		updatedTeam := team
+		updatedTeam.People = []Person{tina}
+
+		assert.NoError(t, ValidateUpdate(&team, &updatedTeam, &tina))
+	})
+
+	t.Run("a team member can be promoted to admin", func(t *testing.T) {
+		updatedTeam := team
+		updatedTeam.People = []Person{tina, chatAdmin}
+
+		assert.NoError(t, ValidateUpdate(&team, &updatedTeam, &tina))
+	})
+
+	t.Run("a team member can be demoted as admin", func(t *testing.T) {
+		teamBefore := team
+		teamBefore.People = []Person{tina, chatAdmin}
+
+		teamAfter := team
+		teamAfter.People = []Person{tina, chat}
+
+		assert.NoError(t, ValidateUpdate(&teamBefore, &teamAfter, &tina))
+	})
+
+	t.Run("a team can be unchanged", func(t *testing.T) {
+		assert.NoError(t, ValidateUpdate(&team, &team, &tina))
+	})
+
+	t.Run("error if I'm not an admin of the original team", func(t *testing.T) {
+		updatedTeam := team
+		updatedTeam.People = []Person{tina, chat, mark}
+
+		assert.Equal(t,
+			fmt.Errorf("you're not a team admin"),
+			ValidateUpdate(&team, &updatedTeam, &chat),
+		)
+	})
+
+	t.Run("error if team UUID changes", func(t *testing.T) {
+		updatedTeam := team
+		updatedTeam.UUID = uuid.Must(uuid.NewV4())
+
+		assert.Equal(t,
+			fmt.Errorf("team UUID cannot be changed"),
+			ValidateUpdate(&team, &updatedTeam, &chat),
+		)
+	})
+
+	t.Run("error if team name changes", func(t *testing.T) {
+		updatedTeam := team
+		updatedTeam.Name = "Updated name"
+
+		assert.Equal(t,
+			fmt.Errorf("team name cannot currently be changed"),
+			ValidateUpdate(&team, &updatedTeam, &chat),
+		)
+	})
+
+	t.Run("error if removing self from team", func(t *testing.T) {
+		updatedTeam := team
+		updatedTeam.People = []Person{chatAdmin}
+
+		assert.Equal(t,
+			fmt.Errorf("can't remove yourself from the team"),
+			ValidateUpdate(&team, &updatedTeam, &tina),
+		)
+	})
+
+	t.Run("error if demoting self as admin", func(t *testing.T) {
+		teamBefore := team
+		teamBefore.People = []Person{tina, chatAdmin}
+
+		teamAfter := team
+		teamAfter.People = []Person{tina, chat}
+
+		assert.Equal(t,
+			fmt.Errorf("can't demote yourself as team admin"),
+			ValidateUpdate(&teamBefore, &teamAfter, &chat),
+		)
+	})
+
+	t.Run("error if email appears twice (different fingerprint)", func(t *testing.T) {
+		updatedTeam := team
+		chatDifferentKey := chat
+		chat.Fingerprint = exampledata.ExampleFingerprint4
+
+		updatedTeam.People = []Person{tina, chat, chatDifferentKey}
+
+		assert.Equal(t,
+			fmt.Errorf("email listed more than once: chat@example.com"),
+			ValidateUpdate(&team, &updatedTeam, &tina),
+		)
+	})
+
+	t.Run("error if fingerprint appears twice (different emails)", func(t *testing.T) {
+		updatedTeam := team
+
+		chatDifferentEmail := chat
+		chat.Email = "chat2@example.com"
+
+		updatedTeam.People = []Person{tina, chat, chatDifferentEmail}
+
+		assert.Equal(t,
+			fmt.Errorf("fingerprint listed more than once: %s", chat.Fingerprint.String()),
+			ValidateUpdate(&team, &updatedTeam, &chat),
+		)
+	})
+
+	t.Run("error if no team members", func(t *testing.T) {
+		updatedTeam := team
+		updatedTeam.People = []Person{}
+
+		assert.Equal(t,
+			fmt.Errorf("team has no members"),
+			ValidateUpdate(&team, &updatedTeam, &chat),
+		)
+	})
+
+	t.Run("error if no team admin", func(t *testing.T) {
+		updatedTeam := team
+		updatedTeam.People = []Person{chat}
+
+		assert.Equal(t,
+			fmt.Errorf("team has no administrators"),
+			ValidateUpdate(&team, &updatedTeam, &chat),
+		)
+	})
+}


### PR DESCRIPTION
when the user is editing a team, we want to make sure they don't make the
team unusable (like changing the UUID, removing all admins etc)

This function codifies those rules.