### PR TITLE
GetUpsertPersonWarnings: flip return args

### DIFF
--- a/fk/teamauthorize.go
+++ b/fk/teamauthorize.go
@@ -134,7 +134,7 @@ func reviewRequests(requests []team.RequestToJoinTeam, myTeam team.Team) (
 		out.Print("» key:   " + colour.Info(request.Fingerprint.String()) + "\n")
 		out.Print("  email: " + colour.Info(request.Email) + "\n")
 
-		err, existingPerson := myTeam.GetUpsertPersonWarnings(team.Person{
+		existingPerson, err := myTeam.GetUpsertPersonWarnings(team.Person{
 			Email:       request.Email,
 			Fingerprint: request.Fingerprint,
 		})

--- a/team/team.go
+++ b/team/team.go
@@ -226,10 +226,10 @@ func (t *Team) GetPersonForFingerprint(fingerprint fpr.Fingerprint) (*Person, er
 
 // GetUpsertPersonWarnings checks if the given request to join a team causes any other team member to
 // be overwritten, returning an error if so.
-func (t *Team) GetUpsertPersonWarnings(newPerson Person) (err error, existingPerson *Person) {
+func (t *Team) GetUpsertPersonWarnings(newPerson Person) (existingPerson *Person, err error) {
 	for _, existingPerson := range t.People {
 		if existingPerson == newPerson {
-			return ErrPersonWouldNotBeChanged, &existingPerson
+			return &existingPerson, ErrPersonWouldNotBeChanged
 		}
 
 		fingerprintsEqual := existingPerson.Fingerprint == newPerson.Fingerprint
@@ -242,20 +242,20 @@ func (t *Team) GetUpsertPersonWarnings(newPerson Person) (err error, existingPer
 		// 4. demoted from admin
 
 		if !fingerprintsEqual && emailsEqual && isAdminsEqual {
-			return ErrKeyWouldBeUpdated, &existingPerson
+			return &existingPerson, ErrKeyWouldBeUpdated
 		}
 
 		if !emailsEqual && fingerprintsEqual && isAdminsEqual {
-			return ErrEmailWouldBeUpdated, &existingPerson
+			return &existingPerson, ErrEmailWouldBeUpdated
 		}
 
 		if !isAdminsEqual && emailsEqual && fingerprintsEqual {
 			isPromotion := !existingPerson.IsAdmin && newPerson.IsAdmin
 
 			if isPromotion {
-				return ErrPersonWouldBePromotedToAdmin, &existingPerson
+				return &existingPerson, ErrPersonWouldBePromotedToAdmin
 			}
-			return ErrPersonWouldBeDemotedAsAdmin, &existingPerson
+			return &existingPerson, ErrPersonWouldBeDemotedAsAdmin
 		}
 
 	}

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -725,7 +725,7 @@ func TestGetUpsertPersonWarnings(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("GetUpsertPersonWarnings for "+test.name, func(t *testing.T) {
-			err, _ := test.team.GetUpsertPersonWarnings(test.person)
+			_, err := test.team.GetUpsertPersonWarnings(test.person)
 			assert.Equal(t, test.expectedError, err)
 		})
 	}


### PR DESCRIPTION
for some reason it was returning error before value, giving linter
errors