### PR TITLE
Add team.Version

### DIFF
--- a/fk/teamauthorize.go
+++ b/fk/teamauthorize.go
@@ -71,6 +71,8 @@ func teamAuthorize() exitCode {
 		approvedRequests, deleteRequests := reviewRequests(requests, myTeam)
 
 		if len(approvedRequests) > 0 {
+			myTeam.Version++
+
 			for _, request := range approvedRequests {
 				myTeam.UpsertPerson(
 					team.Person{

--- a/fk/teamedit.go
+++ b/fk/teamedit.go
@@ -80,6 +80,8 @@ func doEditTeam(myTeam team.Team, me team.Person) exitCode {
 		return 1
 	}
 
+	updatedTeam.Version = myTeam.Version + 1
+
 	if err := team.ValidateUpdate(&myTeam, updatedTeam, &me); err != nil {
 		out.Print(ui.FormatFailure("Problem with new team roster", nil, err))
 		return 1

--- a/team/serialize_test.go
+++ b/team/serialize_test.go
@@ -12,8 +12,9 @@ import (
 func TestSerialize(t *testing.T) {
 	t.Run("for a valid team", func(t *testing.T) {
 		testTeam := Team{
-			Name: "Kiffix",
-			UUID: uuid.Must(uuid.FromString("6caa3730-2ca3-47b9-b671-5dc326100431")),
+			Name:    "Kiffix",
+			UUID:    uuid.Must(uuid.FromString("6caa3730-2ca3-47b9-b671-5dc326100431")),
+			Version: 3,
 			People: []Person{
 				Person{
 					Email:       "test2@example.com",
@@ -36,6 +37,7 @@ func TestSerialize(t *testing.T) {
 # It is used to look up which key to use for an email address and fetch keys
 # automatically.
 uuid = "6caa3730-2ca3-47b9-b671-5dc326100431"
+version = 3
 name = "Kiffix"
 
 [[person]]
@@ -77,6 +79,7 @@ name = "Kiffix"
 # It is used to look up which key to use for an email address and fetch keys
 # automatically.
 uuid = "6caa3730-2ca3-47b9-b671-5dc326100431"
+version = 0
 name = "Kiffix"
 
 [[person]]

--- a/team/team.go
+++ b/team/team.go
@@ -371,9 +371,10 @@ func fileExists(filename string) bool {
 
 // Team represents a group of people in Fluidkeys
 type Team struct {
-	UUID   uuid.UUID `toml:"uuid"`
-	Name   string    `toml:"name"`
-	People []Person  `toml:"person"`
+	UUID    uuid.UUID `toml:"uuid"`
+	Version uint      `toml:"version"`
+	Name    string    `toml:"name"`
+	People  []Person  `toml:"person"`
 
 	roster    string
 	signature string

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -248,6 +248,7 @@ func TestUpdateRoster(t *testing.T) {
 # It is used to look up which key to use for an email address and fetch keys
 # automatically.
 uuid = "74bb40b4-3510-11e9-968e-53c38df634be"
+version = 0
 name = "Kiffix"
 
 [[person]]

--- a/team/validateupdate.go
+++ b/team/validateupdate.go
@@ -32,6 +32,10 @@ func ValidateUpdate(before *Team, after *Team, me *Person) error {
 		return err
 	}
 
+	if err := validateVersionMustIncrementByOne(before, after); err != nil {
+		return err
+	}
+
 	if err := validateIAmAdmin(before, after, me); err != nil {
 		return err
 	}
@@ -57,6 +61,14 @@ func validateTeamUUID(before, after *Team) error {
 func validateTeamNameCantChange(before, after *Team) error {
 	if before.Name != after.Name {
 		return fmt.Errorf("team name cannot currently be changed")
+	}
+	return nil
+}
+
+func validateVersionMustIncrementByOne(before, after *Team) error {
+	if after.Version != before.Version+1 {
+		return fmt.Errorf("invalid version number v%d (expected v%d)",
+			after.Version, before.Version+1)
 	}
 	return nil
 }

--- a/team/validateupdate_test.go
+++ b/team/validateupdate_test.go
@@ -35,27 +35,28 @@ func TestValidateUpate(t *testing.T) {
 	}
 
 	team := Team{
-		UUID:   uuid.Must(uuid.NewV4()),
-		Name:   "Test team",
-		People: []Person{tina, chat},
+		UUID:    uuid.Must(uuid.NewV4()),
+		Version: 2,
+		Name:    "Test team",
+		People:  []Person{tina, chat},
 	}
 
 	t.Run("a team member can be removed", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		updatedTeam.People = []Person{tina, chat, mark}
 
 		assert.NoError(t, ValidateUpdate(&team, &updatedTeam, &tina))
 	})
 
 	t.Run("a team member can be removed", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		updatedTeam.People = []Person{tina}
 
 		assert.NoError(t, ValidateUpdate(&team, &updatedTeam, &tina))
 	})
 
 	t.Run("a team member can be promoted to admin", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		updatedTeam.People = []Person{tina, chatAdmin}
 
 		assert.NoError(t, ValidateUpdate(&team, &updatedTeam, &tina))
@@ -65,18 +66,56 @@ func TestValidateUpate(t *testing.T) {
 		teamBefore := team
 		teamBefore.People = []Person{tina, chatAdmin}
 
-		teamAfter := team
+		teamAfter := bumpVersion(team)
 		teamAfter.People = []Person{tina, chat}
 
 		assert.NoError(t, ValidateUpdate(&teamBefore, &teamAfter, &tina))
 	})
 
-	t.Run("a team can be unchanged", func(t *testing.T) {
-		assert.NoError(t, ValidateUpdate(&team, &team, &tina))
+	t.Run("a team can be unchanged, if version number is incremented", func(t *testing.T) {
+		updatedTeam := bumpVersion(team)
+		assert.NoError(t, ValidateUpdate(&team, &updatedTeam, &tina))
+	})
+
+	t.Run("a team can have its version incremented", func(t *testing.T) {
+		updatedTeam := bumpVersion(team)
+		updatedTeam.Version = team.Version + 1
+
+		assert.NoError(t, ValidateUpdate(&team, &updatedTeam, &tina))
+	})
+
+	t.Run("error if the version number is unchanged", func(t *testing.T) {
+		updatedTeam := bumpVersion(team)
+		updatedTeam.Version = team.Version
+
+		assert.Equal(t,
+			fmt.Errorf("invalid version number v2 (expected v3)"),
+			ValidateUpdate(&team, &updatedTeam, &tina),
+		)
+	})
+
+	t.Run("error if the version number goes down", func(t *testing.T) {
+		updatedTeam := bumpVersion(team)
+		updatedTeam.Version = team.Version - 1
+
+		assert.Equal(t,
+			fmt.Errorf("invalid version number v1 (expected v3)"),
+			ValidateUpdate(&team, &updatedTeam, &tina),
+		)
+	})
+
+	t.Run("error if the version number goes up more than 1", func(t *testing.T) {
+		updatedTeam := bumpVersion(team)
+		updatedTeam.Version = team.Version + 2
+
+		assert.Equal(t,
+			fmt.Errorf("invalid version number v4 (expected v3)"),
+			ValidateUpdate(&team, &updatedTeam, &tina),
+		)
 	})
 
 	t.Run("error if I'm not an admin of the original team", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		updatedTeam.People = []Person{tina, chat, mark}
 
 		assert.Equal(t,
@@ -86,7 +125,7 @@ func TestValidateUpate(t *testing.T) {
 	})
 
 	t.Run("error if team UUID changes", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		updatedTeam.UUID = uuid.Must(uuid.NewV4())
 
 		assert.Equal(t,
@@ -96,7 +135,7 @@ func TestValidateUpate(t *testing.T) {
 	})
 
 	t.Run("error if team name changes", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		updatedTeam.Name = "Updated name"
 
 		assert.Equal(t,
@@ -106,7 +145,7 @@ func TestValidateUpate(t *testing.T) {
 	})
 
 	t.Run("error if removing self from team", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		updatedTeam.People = []Person{chatAdmin}
 
 		assert.Equal(t,
@@ -119,7 +158,7 @@ func TestValidateUpate(t *testing.T) {
 		teamBefore := team
 		teamBefore.People = []Person{tina, chatAdmin}
 
-		teamAfter := team
+		teamAfter := bumpVersion(team)
 		teamAfter.People = []Person{tina, chat}
 
 		assert.Equal(t,
@@ -129,7 +168,7 @@ func TestValidateUpate(t *testing.T) {
 	})
 
 	t.Run("error if email appears twice (different fingerprint)", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		chatDifferentKey := chat
 		chat.Fingerprint = exampledata.ExampleFingerprint4
 
@@ -142,7 +181,7 @@ func TestValidateUpate(t *testing.T) {
 	})
 
 	t.Run("error if fingerprint appears twice (different emails)", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 
 		chatDifferentEmail := chat
 		chat.Email = "chat2@example.com"
@@ -156,7 +195,7 @@ func TestValidateUpate(t *testing.T) {
 	})
 
 	t.Run("error if no team members", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		updatedTeam.People = []Person{}
 
 		assert.Equal(t,
@@ -166,7 +205,7 @@ func TestValidateUpate(t *testing.T) {
 	})
 
 	t.Run("error if no team admin", func(t *testing.T) {
-		updatedTeam := team
+		updatedTeam := bumpVersion(team)
 		updatedTeam.People = []Person{chat}
 
 		assert.Equal(t,
@@ -174,4 +213,10 @@ func TestValidateUpate(t *testing.T) {
 			ValidateUpdate(&team, &updatedTeam, &chat),
 		)
 	})
+}
+
+func bumpVersion(t Team) Team {
+	newTeam := t
+	newTeam.Version = t.Version + 1
+	return newTeam
 }


### PR DESCRIPTION
* `team edit`: increment roster version by 1
* ValidateUpdate: ensure team.Version increments by exactly 1

every time the roster changes, the version must increment by exactly 1.
* this will allow clients to request all the updates to a roster since they first downloaded it (https://trello.com/c/gNGCas7S)
* we'll be able to detect conflicts by 2 admins (https://trello.com/c/APuFCerV)
* we'll be able to protect against replay attacks of old versions of the roster (https://trello.com/c/NrlzZe6e)